### PR TITLE
listBucket returns invalid keys ('/' in front); add support for metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
   "com.github.pathikrit" %% "better-files" % "2.16.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.29",
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.29" % "test",
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test",
   "commons-io" % "commons-io" % "2.5" % "test",
   "ch.qos.logback" % "logback-classic" % "1.1.7" % "test"

--- a/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
@@ -1,13 +1,16 @@
 package io.findify.s3mock.provider
+import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.util.UUID
 
 import akka.http.scaladsl.model.DateTime
 import better.files.File
 import better.files.File.OpenOptions
+import com.amazonaws.services.s3.model.ObjectMetadata
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.error.{NoSuchBucketException, NoSuchKeyException}
 import io.findify.s3mock.request.{CompleteMultipartUpload, CreateBucketConfiguration}
 import io.findify.s3mock.response._
+
 import scala.util.Random
 
 /**
@@ -62,11 +65,24 @@ class FileProvider(dir:String) extends Provider with LazyLogging {
     logger.debug(s"crating bucket $name")
     CreateBucket(name)
   }
-  def putObject(bucket:String, key:String, data:Array[Byte]): Unit = {
+  def putObject(bucket:String, key:String, data:Array[Byte], objectMetadata: ObjectMetadata = null): Unit = {
     createDir(s"$dir/$bucket/$key")
     val file = File(s"$dir/$bucket/$key")
     logger.debug(s"writing file for s3://$bucket/$key to $dir/$bucket/$key, bytes = ${data.length}")
     file.write(data)(OpenOptions.default)
+
+    if(objectMetadata != null) {
+      val split = key.split("/").toBuffer
+      val metaFileName = split.dropRight(1)
+      metaFileName.append(s".${split.last}")
+
+      val metaDataFile = File(s"$dir/$bucket/${metaFileName.mkString}")
+
+      val stream: ObjectOutputStream = new ObjectOutputStream(metaDataFile.newOutputStream(OpenOptions.default))
+      stream.writeObject(objectMetadata)
+      stream.flush()
+      stream.close()
+    }
   }
   def getObject(bucket:String, key:String):Array[Byte] = {
     val file = File(s"$dir/$bucket/$key")
@@ -74,6 +90,17 @@ class FileProvider(dir:String) extends Provider with LazyLogging {
     if (!file.exists) throw NoSuchKeyException(bucket, key)
     file.byteArray
   }
+
+  def getMetaData(bucket:String, key:String):ObjectMetadata = {
+    val split = key.split("/").toBuffer
+    val metaFileName = split.dropRight(1)
+    metaFileName.append(s".${split.last}")
+
+    val file = File(s"$dir/$bucket/${metaFileName.mkString}")
+    logger.debug(s"reading object for s://$bucket/${metaFileName.mkString}")
+    if (!file.exists) null else new ObjectInputStream(file.newInputStream).readObject().asInstanceOf[ObjectMetadata]
+  }
+
   def putObjectMultipartStart(bucket:String, key:String):InitiateMultipartUploadResult = {
     val id = Math.abs(Random.nextLong()).toString
     createDir(s"$dir/.mp/$bucket/$key/$id/.keep")

--- a/src/main/scala/io/findify/s3mock/provider/Provider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/Provider.scala
@@ -1,5 +1,6 @@
 package io.findify.s3mock.provider
 
+import com.amazonaws.services.s3.model.ObjectMetadata
 import io.findify.s3mock.request.{CompleteMultipartUpload, CreateBucketConfiguration}
 import io.findify.s3mock.response._
 
@@ -10,8 +11,9 @@ trait Provider {
   def listBuckets:ListAllMyBuckets
   def listBucket(bucket:String, prefix:String):ListBucket
   def createBucket(name:String, bucketConfig:CreateBucketConfiguration):CreateBucket
-  def putObject(bucket:String, key:String, data:Array[Byte]):Unit
+  def putObject(bucket:String, key:String, data:Array[Byte], metadata: ObjectMetadata = null):Unit
   def getObject(bucket:String, key:String):Array[Byte]
+  def getMetaData(bucket:String, key:String):ObjectMetadata
   def putObjectMultipartStart(bucket:String, key:String):InitiateMultipartUploadResult
   def putObjectMultipartPart(bucket:String, key:String, partNumber:Int, uploadId:String, data:Array[Byte]):Unit
   def putObjectMultipartComplete(bucket:String, key:String, uploadId:String, request:CompleteMultipartUpload):CompleteMultipartUploadResult

--- a/src/main/scala/io/findify/s3mock/route/GetObject.scala
+++ b/src/main/scala/io/findify/s3mock/route/GetObject.scala
@@ -1,25 +1,72 @@
 package io.findify.s3mock.route
 
-import akka.http.scaladsl.model.headers.{`Content-Length`, `Last-Modified`}
+import java.util.Date
+
+import akka.http.scaladsl.model.HttpEntity.Strict
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{RawHeader, `Last-Modified`}
 import akka.http.scaladsl.server.Directives._
-import akka.stream.scaladsl.Source
+import com.amazonaws.services.s3.Headers
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.util.DateUtils
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.provider.Provider
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 /**
   * Created by shutty on 8/19/16.
   */
-case class GetObject(implicit provider:Provider) extends LazyLogging {
-  def route(bucket:String, path:String) = get {
+case class GetObject(implicit provider: Provider) extends LazyLogging {
+  def route(bucket: String, path: String) = get {
     complete {
       logger.debug(s"get object: bucket=$bucket, path=$path")
+
       Try(provider.getObject(bucket, path)) match {
-        case Success(data) => HttpResponse(StatusCodes.OK, entity = HttpEntity(data), headers = List(`Last-Modified`(DateTime(1970,1,1))))
+        case Success(data) =>
+          val meta: ObjectMetadata = provider.getMetaData(bucket, path)
+          val entity: Strict = if (meta != null) ContentType.parse(meta.getContentType) match {
+            case Right(value) => HttpEntity(value, data)
+            case Left(error) => HttpEntity(data)
+          } else HttpEntity(data)
+
+          HttpResponse(
+            status = StatusCodes.OK,
+            entity = entity,
+            headers = `Last-Modified`(DateTime(1970, 1, 1)) :: metadataToHeaderList(meta)
+          )
         case Failure(_) => HttpResponse(StatusCodes.NotFound)
       }
     }
+  }
+
+  protected def metadataToHeaderList(metadata: ObjectMetadata): List[RawHeader] = {
+    val headerList = scala.collection.mutable.ListBuffer.empty[RawHeader]
+    if (metadata == null) return headerList.toList
+
+    val rawMetadata: mutable.Map[String, AnyRef] = metadata.getRawMetadata.asScala
+    if (rawMetadata != null) {
+      import scala.collection.JavaConversions._
+      for (entry <- rawMetadata.entrySet) {
+        headerList.append(RawHeader(entry.getKey, entry.getValue.toString))
+      }
+    }
+
+    val httpExpiresDate: Date = metadata.getHttpExpiresDate
+    if (httpExpiresDate != null) headerList.append(RawHeader(Headers.EXPIRES, DateUtils.formatRFC822Date(httpExpiresDate)))
+    val userMetadata: mutable.Map[String, String] = metadata.getUserMetadata.asScala
+    if (userMetadata != null) {
+      import scala.collection.JavaConversions._
+      for (entry <- userMetadata.entrySet) {
+        var key: String = entry.getKey
+        var value: String = entry.getValue
+        if (key != null) key = key.trim
+        if (value != null) value = value.trim
+        headerList.append(RawHeader(Headers.S3_USER_METADATA_PREFIX + key, value))
+      }
+    }
+    headerList.toList
   }
 }

--- a/src/main/scala/io/findify/s3mock/route/PutObject.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObject.scala
@@ -1,15 +1,24 @@
 package io.findify.s3mock.route
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import java.lang.Iterable
+import java.util
+
+import akka.http.javadsl.model.HttpHeader
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
+import com.amazonaws.AmazonClientException
+import com.amazonaws.services.s3.Headers
+import com.amazonaws.services.s3.internal.ServiceUtils
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.util.{DateUtils, StringUtils}
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.S3ChunkedProtocolStage
 import io.findify.s3mock.provider.Provider
 
-import scala.concurrent.Future
+import scala.collection.JavaConverters._
 
 /**
   * Created by shutty on 8/20/16.
@@ -28,12 +37,16 @@ case class PutObject(implicit provider:Provider, mat:Materializer) extends LazyL
 
   def completeSigned(bucket:String, path:String) = extractRequest { request =>
     complete {
+
+      val metadata: ObjectMetadata = new ObjectMetadata()
+      populateObjectMetadata(request, metadata)
+
       logger.info(s"put object $bucket/$path (signed)")
       val result = request.entity.dataBytes
         .via(new S3ChunkedProtocolStage)
         .fold(ByteString(""))(_ ++ _)
         .map(data => {
-          provider.putObject(bucket, path, data.toArray)
+          provider.putObject(bucket, path, data.toArray, metadata)
           HttpResponse(StatusCodes.OK)
         }).runWith(Sink.head[HttpResponse])
       result
@@ -42,14 +55,72 @@ case class PutObject(implicit provider:Provider, mat:Materializer) extends LazyL
 
   def completePlain(bucket:String, path:String) = extractRequest { request =>
     complete {
+      val metadata: ObjectMetadata = new ObjectMetadata()
+      populateObjectMetadata(request, metadata)
+
       logger.info(s"put object $bucket/$path (unsigned)")
       val result = request.entity.dataBytes
         .fold(ByteString(""))(_ ++ _)
         .map(data => {
-          provider.putObject(bucket, path, data.toArray)
+          provider.putObject(bucket, path, data.toArray, metadata)
           HttpResponse(StatusCodes.OK)
         }).runWith(Sink.head[HttpResponse])
       result
+    }
+  }
+
+  private def populateObjectMetadata(request: HttpRequest, metadata: ObjectMetadata) {
+    val ignoredHeaders: util.HashSet[String] = new util.HashSet[String]()
+    ignoredHeaders.add(Headers.DATE)
+    ignoredHeaders.add(Headers.SERVER)
+    ignoredHeaders.add(Headers.REQUEST_ID)
+    ignoredHeaders.add(Headers.EXTENDED_REQUEST_ID)
+    ignoredHeaders.add(Headers.CLOUD_FRONT_ID)
+    ignoredHeaders.add(Headers.CONNECTION)
+
+    val headers: Iterable[HttpHeader] = request.getHeaders()
+    for (header <- headers.asScala) {
+      var key: String = header.name()
+      if (StringUtils.beginsWithIgnoreCase(key, Headers.S3_USER_METADATA_PREFIX)) {
+        key = key.substring(Headers.S3_USER_METADATA_PREFIX.length)
+        metadata.addUserMetadata(key, header.value())
+      }
+      //      else if (ignoredHeaders.contains(key)) {
+      // ignore...
+      //      }
+      else if (key.equalsIgnoreCase(Headers.LAST_MODIFIED)) try
+        metadata.setHeader(key, ServiceUtils.parseRfc822Date(header.value()))
+
+      catch {
+        case pe: Exception => logger.warn("Unable to parse last modified date: " + header.value(), pe)
+      }
+      else if (key.equalsIgnoreCase(Headers.CONTENT_LENGTH)) try
+        metadata.setHeader(key, java.lang.Long.parseLong(header.value()))
+
+      catch {
+        case nfe: NumberFormatException => throw new AmazonClientException("Unable to parse content length. Header 'Content-Length' has corrupted data" + nfe.getMessage, nfe)
+      }
+      else if (key.equalsIgnoreCase(Headers.ETAG)) metadata.setHeader(key, ServiceUtils.removeQuotes(header.value()))
+      else if (key.equalsIgnoreCase(Headers.EXPIRES)) try
+        metadata.setHttpExpiresDate(DateUtils.parseRFC822Date(header.value()))
+
+      catch {
+        case pe: Exception => logger.warn("Unable to parse http expiration date: " + header.value(), pe)
+      }
+      //      else if (key.equalsIgnoreCase(Headers.EXPIRATION)) new ObjectExpirationHeaderHandler[ObjectMetadata]().handle(metadata, response)
+      //      else if (key.equalsIgnoreCase(Headers.RESTORE)) new ObjectRestoreHeaderHandler[ObjectRestoreResult]().handle(metadata, response)
+      //      else if (key.equalsIgnoreCase(Headers.REQUESTER_CHARGED_HEADER)) new S3RequesterChargedHeaderHandler[S3RequesterChargedResult]().handle(metadata, response)
+      else if (key.equalsIgnoreCase(Headers.S3_PARTS_COUNT)) try
+        metadata.setHeader(key, header.value().toInt)
+
+      catch {
+        case nfe: NumberFormatException => throw new AmazonClientException("Unable to parse part count. Header x-amz-mp-parts-count has corrupted data" + nfe.getMessage, nfe)
+      }
+      else metadata.setHeader(key, header.value())
+    }
+
+    if(metadata.getContentType == null){
+      metadata.setContentType(request.entity.getContentType.toString)
     }
   }
 

--- a/src/test/scala/io/findify/s3mock/GetPutObjectWithMetadataTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectWithMetadataTest.scala
@@ -1,0 +1,70 @@
+package io.findify.s3mock
+
+import java.nio.charset.Charset
+
+import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
+import org.apache.commons.io.IOUtils
+
+import scala.collection.JavaConversions._
+
+/**
+  * Created by shutty on 8/10/16.
+  */
+class GetPutObjectWithMetadataTest extends S3MockTest {
+  "s3 mock" should "put object with metadata" in {
+    s3.createBucket("getput").getName shouldBe "getput"
+    s3.listBuckets().exists(_.getName == "getput") shouldBe true
+
+    val is = IOUtils.toInputStream("bar", Charset.forName("UTF-8"))
+    val metadata: ObjectMetadata = new ObjectMetadata()
+    metadata.setContentType("application/json")
+    metadata.setUserMetadata(Map("metamaic" -> "maic"))
+
+    s3.putObject("getput", "foo", is, metadata)
+
+    val s3Object: S3Object = s3.getObject("getput", "foo")
+    val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
+    actualMetadata.getContentType shouldBe "application/json"
+
+    val result = IOUtils.toString(s3Object.getObjectContent, Charset.forName("UTF-8"))
+    result shouldBe "bar"
+  }
+
+  "s3 mock" should "put object with metadata, but skip unvalid content-type" in {
+    s3.createBucket("getput").getName shouldBe "getput"
+    s3.listBuckets().exists(_.getName == "getput") shouldBe true
+
+    val is = IOUtils.toInputStream("bar", Charset.forName("UTF-8"))
+    val metadata: ObjectMetadata = new ObjectMetadata()
+    metadata.setContentType("application")
+    metadata.setUserMetadata(Map("metamaic" -> "maic"))
+
+    s3.putObject("getput", "foo", is, metadata)
+
+    val s3Object: S3Object = s3.getObject("getput", "foo")
+    val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
+    actualMetadata.getContentType shouldBe "application/octet-stream"
+
+    val result = IOUtils.toString(s3Object.getObjectContent, Charset.forName("UTF-8"))
+    result shouldBe "bar"
+  }
+  "s3 mock" should "put object in subdirs with metadata, but skip unvalid content-type" in {
+    s3.createBucket("getput").getName shouldBe "getput"
+    s3.listBuckets().exists(_.getName == "getput") shouldBe true
+
+    val is = IOUtils.toInputStream("bar", Charset.forName("UTF-8"))
+    val metadata: ObjectMetadata = new ObjectMetadata()
+    metadata.setContentType("application")
+    metadata.setUserMetadata(Map("metamaic" -> "maic"))
+
+    s3.putObject("getput", "foo1/bar", is, metadata)
+
+    val s3Object: S3Object = s3.getObject("getput", "foo1/bar")
+    val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
+    actualMetadata.getContentType shouldBe "application/octet-stream"
+
+    val result = IOUtils.toString(s3Object.getObjectContent, Charset.forName("UTF-8"))
+    result shouldBe "bar"
+  }
+
+}

--- a/src/test/scala/io/findify/s3mock/ListBucketEmptyWorkdirTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketEmptyWorkdirTest.scala
@@ -30,7 +30,7 @@ class ListBucketEmptyWorkdirTest extends FlatSpec with Matchers with BeforeAndAf
     s3.putObject("list", "foo1", "xxx")
     s3.putObject("list", "foo2", "xxx")
     val list = s3.listObjects("list").getObjectSummaries.asScala.toList
-    list.map(_.getKey).forall(_.startsWith("/foo")) shouldBe true
+    list.map(_.getKey).forall(_.startsWith("foo")) shouldBe true
   }
 
 

--- a/src/test/scala/io/findify/s3mock/ListBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketTest.scala
@@ -1,5 +1,9 @@
 package io.findify.s3mock
 
+import java.util
+
+import com.amazonaws.services.s3.model.S3ObjectSummary
+
 import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
 
@@ -33,5 +37,14 @@ class ListBucketTest extends S3MockTest {
     s3.putObject("list3", "one/xfoo3", "xxx")
     s3.listObjects("list3", "qaz/qax").getObjectSummaries.asScala.isEmpty shouldBe true
 
+  }
+  it should "return keys with valid keys (when no prefix given)" in {
+    s3.createBucket("list4")
+    s3.putObject("list4", "one", "xxx")
+    val summaries: util.List[S3ObjectSummary] = s3.listObjects("list4").getObjectSummaries
+    summaries.size() shouldBe 1
+
+    val returnedKey = summaries.last.getKey
+    s3.getObject("list4", returnedKey).getKey shouldBe "one"
   }
 }


### PR DESCRIPTION
The listBucket method returns list of entries with invalid keys.
The given keys contain an leading "/" which has to be dropped to query the object.

Add metadata support.