### PR TITLE
fix a method call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Scala:
     
     // create and start S3 API mock
     val api = S3Mock(port = 8001, dir = "/tmp/s3")
-    api.start()
+    api.start
 
     // AWS S3 client setup
     val credentials = new AnonymousAWSCredentials()


### PR DESCRIPTION
Inconveniently, Scala distinguishes a method without parentheses and a method with empty parentheses.
http://stackoverflow.com/questions/7409502/what-is-the-difference-between-def-foo-and-def-foo-in-scala