### PR TITLE
Use stanard Source class instead of Apache Commons IO in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.83",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "commons-io" % "commons-io" % "2.5" % "test",
   "ch.qos.logback" % "logback-classic" % "1.1.9" % "test"
 )
 

--- a/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
@@ -1,7 +1,6 @@
 package io.findify.s3mock
 
 import java.io.ByteArrayInputStream
-import java.nio.charset.Charset
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -11,8 +10,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 
 import scala.concurrent.duration._
 import scala.collection.JavaConversions._
-import org.apache.commons.io.IOUtils
-
 import scala.concurrent.Await
 import scala.util.Random
 
@@ -24,7 +21,7 @@ class GetPutObjectTest extends S3MockTest {
     s3.createBucket("getput").getName shouldBe "getput"
     s3.listBuckets().exists(_.getName == "getput") shouldBe true
     s3.putObject("getput", "foo", "bar")
-    val result = IOUtils.toString(s3.getObject("getput", "foo").getObjectContent, Charset.forName("UTF-8"))
+    val result = getContent(s3.getObject("getput", "foo"))
     result shouldBe "bar"
   }
   it should "be able to post data" in {
@@ -33,22 +30,22 @@ class GetPutObjectTest extends S3MockTest {
     val http = Http(system)
     if (!s3.listBuckets().exists(_.getName == "getput")) s3.createBucket("getput")
     val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = "http://127.0.0.1:8001/getput/foo2", entity = "bar")), 10.seconds)
-    IOUtils.toString(s3.getObject("getput", "foo2").getObjectContent, Charset.forName("UTF-8")) shouldBe "bar"
+    getContent(s3.getObject("getput", "foo2")) shouldBe "bar"
   }
   it should "put objects in subdirs" in {
     s3.putObject("getput", "foo1/foo2/foo3", "bar")
-    val result = IOUtils.toString(s3.getObject("getput", "foo1/foo2/foo3").getObjectContent, Charset.forName("UTF-8"))
+    val result = getContent(s3.getObject("getput", "foo1/foo2/foo3"))
     result shouldBe "bar"
   }
   it should "not drop \\r\\n symbols" in {
     s3.putObject("getput", "foorn", "bar\r\nbaz")
-    val result = IOUtils.toString(s3.getObject("getput", "foorn").getObjectContent, Charset.forName("UTF-8"))
+    val result = getContent(s3.getObject("getput", "foorn"))
     result shouldBe "bar\r\nbaz"
   }
   it should "put & get large binary blobs" in {
     val blob = Random.nextString(1024000).getBytes("UTF-8")
     s3.putObject("getput", "foolarge", new ByteArrayInputStream(blob), new ObjectMetadata())
-    val result = IOUtils.toByteArray(s3.getObject("getput", "foolarge").getObjectContent)
+    val result = getContent(s3.getObject("getput", "foolarge")).getBytes("UTF-8")
     result shouldBe blob
   }
 }

--- a/src/test/scala/io/findify/s3mock/GetPutObjectWithMetadataTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectWithMetadataTest.scala
@@ -1,9 +1,8 @@
 package io.findify.s3mock
 
-import java.nio.charset.Charset
+import java.io.ByteArrayInputStream
 
 import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
-import org.apache.commons.io.IOUtils
 
 import scala.collection.JavaConversions._
 
@@ -15,7 +14,7 @@ class GetPutObjectWithMetadataTest extends S3MockTest {
     s3.createBucket("getput").getName shouldBe "getput"
     s3.listBuckets().exists(_.getName == "getput") shouldBe true
 
-    val is = IOUtils.toInputStream("bar", Charset.forName("UTF-8"))
+    val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
     val metadata: ObjectMetadata = new ObjectMetadata()
     metadata.setContentType("application/json")
     metadata.setUserMetadata(Map("metamaic" -> "maic"))
@@ -26,15 +25,14 @@ class GetPutObjectWithMetadataTest extends S3MockTest {
     val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
     actualMetadata.getContentType shouldBe "application/json"
 
-    val result = IOUtils.toString(s3Object.getObjectContent, Charset.forName("UTF-8"))
-    result shouldBe "bar"
+    getContent(s3Object) shouldBe "bar"
   }
 
   "s3 mock" should "put object with metadata, but skip unvalid content-type" in {
     s3.createBucket("getput").getName shouldBe "getput"
     s3.listBuckets().exists(_.getName == "getput") shouldBe true
 
-    val is = IOUtils.toInputStream("bar", Charset.forName("UTF-8"))
+    val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
     val metadata: ObjectMetadata = new ObjectMetadata()
     metadata.setContentType("application")
     metadata.setUserMetadata(Map("metamaic" -> "maic"))
@@ -45,14 +43,13 @@ class GetPutObjectWithMetadataTest extends S3MockTest {
     val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
     actualMetadata.getContentType shouldBe "application/octet-stream"
 
-    val result = IOUtils.toString(s3Object.getObjectContent, Charset.forName("UTF-8"))
-    result shouldBe "bar"
+    getContent(s3Object) shouldBe "bar"
   }
   "s3 mock" should "put object in subdirs with metadata, but skip unvalid content-type" in {
     s3.createBucket("getput").getName shouldBe "getput"
     s3.listBuckets().exists(_.getName == "getput") shouldBe true
 
-    val is = IOUtils.toInputStream("bar", Charset.forName("UTF-8"))
+    val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
     val metadata: ObjectMetadata = new ObjectMetadata()
     metadata.setContentType("application")
     metadata.setUserMetadata(Map("metamaic" -> "maic"))
@@ -63,8 +60,7 @@ class GetPutObjectWithMetadataTest extends S3MockTest {
     val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
     actualMetadata.getContentType shouldBe "application/octet-stream"
 
-    val result = IOUtils.toString(s3Object.getObjectContent, Charset.forName("UTF-8"))
-    result shouldBe "bar"
+    getContent(s3Object) shouldBe "bar"
   }
 
 }

--- a/src/test/scala/io/findify/s3mock/JavaExampleTest.scala
+++ b/src/test/scala/io/findify/s3mock/JavaExampleTest.scala
@@ -1,6 +1,5 @@
 package io.findify.s3mock
 
-import java.nio.charset.Charset
 import java.util.UUID
 
 import scala.collection.JavaConversions._
@@ -8,8 +7,9 @@ import better.files.File
 import com.amazonaws.auth.{AnonymousAWSCredentials, BasicAWSCredentials}
 import com.amazonaws.services.s3.AmazonS3Client
 import io.findify.s3mock.provider.FileProvider
-import org.apache.commons.io.IOUtils
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.io.Source
 
 /**
   * Created by shutty on 8/19/16.
@@ -35,7 +35,7 @@ class JavaExampleTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     s3.createBucket("getput").getName shouldBe "getput"
     s3.listBuckets().exists(_.getName == "getput") shouldBe true
     s3.putObject("getput", "foo", "bar")
-    val result = IOUtils.toString(s3.getObject("getput", "foo").getObjectContent, Charset.forName("UTF-8"))
+    val result = Source.fromInputStream(s3.getObject("getput", "foo").getObjectContent, "UTF-8").mkString
     result shouldBe "bar"
   }
 
@@ -43,7 +43,7 @@ class JavaExampleTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val s3b = new AmazonS3Client(new BasicAWSCredentials("foo", "bar"))
     s3b.setEndpoint("http://127.0.0.1:8001")
     s3b.putObject("getput", "foo2", "bar2")
-    val result = IOUtils.toString(s3b.getObject("getput", "foo2").getObjectContent, Charset.forName("UTF-8"))
+    val result = Source.fromInputStream(s3b.getObject("getput", "foo2").getObjectContent, "UTF-8").mkString
     result shouldBe "bar2"
 
   }

--- a/src/test/scala/io/findify/s3mock/MultipartUploadTest.scala
+++ b/src/test/scala/io/findify/s3mock/MultipartUploadTest.scala
@@ -2,7 +2,6 @@ package io.findify.s3mock
 
 import java.io.ByteArrayInputStream
 import java.nio.charset.Charset
-import java.util
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -12,7 +11,6 @@ import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import com.amazonaws.services.s3.model.{CompleteMultipartUploadRequest, InitiateMultipartUploadRequest, UploadPartRequest}
 import org.apache.commons.codec.digest.DigestUtils
-import org.apache.commons.io.IOUtils
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -48,7 +46,7 @@ class MultipartUploadTest extends S3MockTest {
     val response4 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:8001/getput/foo2?uploadId=$uploadId", entity = commit)), 10.minutes)
     response4.status.intValue() shouldBe 200
 
-    IOUtils.toString(s3.getObject("getput", "foo2").getObjectContent, Charset.forName("UTF-8")) shouldBe "fooboo"
+    getContent(s3.getObject("getput", "foo2")) shouldBe "fooboo"
   }
 
   it should "work with java sdk" in {
@@ -58,19 +56,19 @@ class MultipartUploadTest extends S3MockTest {
     val p2 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(10).withKey("foo4").withPartNumber(2).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("worldworld".getBytes())))
     val result = s3.completeMultipartUpload(new CompleteMultipartUploadRequest("getput", "foo4", init.getUploadId, List(p1.getPartETag, p2.getPartETag).asJava))
     result.getKey shouldBe "foo4"
-    IOUtils.toString(s3.getObject("getput", "foo4").getObjectContent, Charset.forName("UTF-8")) shouldBe "hellohelloworldworld"
+    getContent(s3.getObject("getput", "foo4")) shouldBe "hellohelloworldworld"
   }
   it should "work with large blobs" in {
     val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("getput", "fooLarge"))
     val blobs = for ( i <- 0 to 200) yield {
-      var blob1 = new Array[Byte](10000)
+      val blob1 = new Array[Byte](10000)
       Random.nextBytes(blob1)
       val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(blob1.length).withKey("fooLarge").withPartNumber(i).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream(blob1)))
       blob1 -> p1.getPartETag
     }
     val result = s3.completeMultipartUpload(new CompleteMultipartUploadRequest("getput", "fooLarge", init.getUploadId, blobs.map(_._2).asJava))
     result.getKey shouldBe "fooLarge"
-    DigestUtils.md5Hex(IOUtils.toByteArray(s3.getObject("getput", "fooLarge").getObjectContent)) shouldBe DigestUtils.md5Hex(blobs.map(_._1).fold(Array[Byte]())(_ ++ _))
+    DigestUtils.md5Hex(s3.getObject("getput", "fooLarge").getObjectContent) shouldBe DigestUtils.md5Hex(blobs.map(_._1).fold(Array[Byte]())(_ ++ _))
 
     
   }

--- a/src/test/scala/io/findify/s3mock/S3MockTest.scala
+++ b/src/test/scala/io/findify/s3mock/S3MockTest.scala
@@ -5,8 +5,11 @@ import java.util.UUID
 import better.files.File
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.S3Object
 import io.findify.s3mock.provider.FileProvider
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.io.Source
 
 /**
   * Created by shutty on 8/9/16.
@@ -28,4 +31,7 @@ trait S3MockTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     server.stop
     File(workDir).delete()
   }
+
+  def getContent(s3Object: S3Object): String = Source.fromInputStream(s3Object.getObjectContent, "UTF-8").mkString
+
 }

--- a/src/test/scala/io/findify/s3mock/transfermanager/PutGetTest.scala
+++ b/src/test/scala/io/findify/s3mock/transfermanager/PutGetTest.scala
@@ -1,12 +1,12 @@
 package io.findify.s3mock.transfermanager
 
 import java.io.{ByteArrayInputStream, File, FileInputStream}
-import java.nio.charset.Charset
 
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 import io.findify.s3mock.S3MockTest
-import org.apache.commons.io.IOUtils
+
+import scala.io.Source
 
 /**
   * Created by shutty on 11/23/16.
@@ -30,7 +30,7 @@ class PutGetTest extends S3MockTest {
     val file = File.createTempFile("hello1", ".s3mock")
     val download = tm.download("tm1", "hello1", file)
     download.waitForCompletion()
-    val result = IOUtils.toString(new FileInputStream(file), Charset.forName("UTF-8"))
+    val result = Source.fromInputStream(new FileInputStream(file), "UTF-8").mkString
     result shouldBe "hello"
   }
 
@@ -39,6 +39,6 @@ class PutGetTest extends S3MockTest {
     val result = copy.waitForCopyResult()
     result.getDestinationKey shouldBe "hello2"
     val hello2 = s3.getObject("tm1", "hello2")
-    IOUtils.toString(hello2.getObjectContent, Charset.forName("UTF-8")) shouldBe "hello"
+    getContent(hello2) shouldBe "hello"
   }
 }


### PR DESCRIPTION
# What is this PR?

When I checked the unit tests I faced that Apache Commons IO is used to play with inputstream/byte arrays in the following way: 

`IOUtils.toString(s3.getObject("getput", "foo2").getObjectContent, Charset.forName("UTF-8"))`

Using the standard Scala [Source](http://www.scala-lang.org/api/2.12.0/scala/io/Source$.html#fromInputStream(is:java.io.InputStream,enc:String):scala.io.BufferedSource) class, the previous line can be rewritten as:

`Source.fromInputStream(s3Object.getObjectContent, "UTF-8").mkString`

Which is a bit easier to read and relies on a standard library solution instead of an external dependency. I created a `getContent` method to remove code duplications which uses the Source class to get the content of an S3 object.

Commons IO was used only in tests, so the dependency was removed.