### PR TITLE
Throw NoSuckBucket error if bucket does not exist

### DIFF
--- a/src/main/scala/io/findify/s3mock/error/InternalErrorException.scala
+++ b/src/main/scala/io/findify/s3mock/error/InternalErrorException.scala
@@ -1,0 +1,10 @@
+package io.findify.s3mock.error
+
+
+case class InternalErrorException(throwable: Throwable) extends Exception(s"Internal server error", throwable) {
+  def toXML =
+    <Error>
+      <Code>InternalError</Code>
+      <Message>{throwable.getMessage}</Message>
+    </Error>
+}

--- a/src/main/scala/io/findify/s3mock/error/NoSuchBucketException.scala
+++ b/src/main/scala/io/findify/s3mock/error/NoSuchBucketException.scala
@@ -3,4 +3,10 @@ package io.findify.s3mock.error
 /**
   * Created by shutty on 8/11/16.
   */
-case class NoSuchBucketException(bucket:String) extends Exception(s"bucket does not exist: s3://$bucket")
+case class NoSuchBucketException(bucket:String) extends Exception(s"bucket does not exist: s3://$bucket") {
+  def toXML = <Error>
+    <Code>NoSuchBucket</Code>
+    <Message>The specified bucket does not exist</Message>
+    <BucketName>{bucket}</BucketName>
+  </Error>
+}

--- a/src/main/scala/io/findify/s3mock/route/GetObject.scala
+++ b/src/main/scala/io/findify/s3mock/route/GetObject.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.s3.Headers
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.util.DateUtils
 import com.typesafe.scalalogging.LazyLogging
-import io.findify.s3mock.error.NoSuchKeyException
+import io.findify.s3mock.error.{InternalErrorException, NoSuchBucketException, NoSuchKeyException}
 import io.findify.s3mock.provider.Provider
 
 import scala.collection.JavaConverters._
@@ -48,7 +48,16 @@ case class GetObject(implicit provider: Provider) extends LazyLogging {
             StatusCodes.NotFound,
             entity = e.toXML.toString()
           )
-        case Failure(_) => HttpResponse(StatusCodes.NotFound)
+        case Failure(e: NoSuchBucketException) =>
+          HttpResponse(
+            StatusCodes.NotFound,
+            entity = e.toXML.toString()
+          )
+        case Failure(t) =>
+          HttpResponse(
+            StatusCodes.InternalServerError,
+            entity = InternalErrorException(t).toXML.toString()
+          )
       }
     }
   }

--- a/src/main/scala/io/findify/s3mock/route/ListBucket.scala
+++ b/src/main/scala/io/findify/s3mock/route/ListBucket.scala
@@ -3,7 +3,10 @@ package io.findify.s3mock.route
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import com.typesafe.scalalogging.LazyLogging
+import io.findify.s3mock.error.{InternalErrorException, NoSuchBucketException}
 import io.findify.s3mock.provider.Provider
+
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by shutty on 8/19/16.
@@ -13,11 +16,36 @@ case class ListBucket(implicit provider:Provider) extends LazyLogging {
     parameter('prefix) { prefix =>
       complete {
         logger.info(s"listing bucket $bucket with prefix=$prefix")
-        HttpResponse(StatusCodes.OK, entity = provider.listBucket(bucket, prefix).toXML.toString)
+        Try(provider.listBucket(bucket, prefix)) match {
+          case Success(l) => HttpResponse(StatusCodes.OK, entity = l.toXML.toString)
+          case Failure(e: NoSuchBucketException) =>
+            HttpResponse(
+              StatusCodes.NotFound,
+              entity = e.toXML.toString()
+            )
+          case Failure(t) =>
+            HttpResponse(
+              StatusCodes.InternalServerError,
+              entity = InternalErrorException(t).toXML.toString()
+            )
+        }
       }
     } ~ complete {
       logger.info(s"listing bucket $bucket")
-      HttpResponse(StatusCodes.OK, entity = provider.listBucket(bucket, "").toXML.toString)
+      Try(provider.listBucket(bucket, "")) match {
+        case Success(l) => HttpResponse(StatusCodes.OK, entity = l.toXML.toString)
+        case Failure(e: NoSuchBucketException) =>
+          HttpResponse(
+            StatusCodes.NotFound,
+            entity = e.toXML.toString()
+          )
+        case Failure(t) =>
+          HttpResponse(
+            StatusCodes.InternalServerError,
+            entity = InternalErrorException(t).toXML.toString()
+          )
+      }
+
     }
   }
 }

--- a/src/main/scala/io/findify/s3mock/route/PutObjectMultipartComplete.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObjectMultipartComplete.scala
@@ -3,8 +3,11 @@ package io.findify.s3mock.route
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import com.typesafe.scalalogging.LazyLogging
+import io.findify.s3mock.error.{InternalErrorException, NoSuchBucketException}
 import io.findify.s3mock.provider.Provider
 import io.findify.s3mock.request.CompleteMultipartUpload
+
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by shutty on 8/20/16.
@@ -16,8 +19,19 @@ case class PutObjectMultipartComplete(implicit provider:Provider) extends LazyLo
         complete {
           logger.info(s"multipart upload completed for $bucket/$path, id = $uploadId")
           val request = CompleteMultipartUpload(scala.xml.XML.loadString(xml).head)
-          val response = provider.putObjectMultipartComplete(bucket, path, uploadId, request)
-          HttpResponse(StatusCodes.OK, entity = response.toXML.toString)
+          Try(provider.putObjectMultipartComplete(bucket, path, uploadId, request)) match {
+            case Success(response) => HttpResponse(StatusCodes.OK, entity = response.toXML.toString)
+            case Failure(e: NoSuchBucketException) =>
+              HttpResponse(
+                StatusCodes.NotFound,
+                entity = e.toXML.toString()
+              )
+            case Failure(t) =>
+              HttpResponse(
+                StatusCodes.InternalServerError,
+                entity = InternalErrorException(t).toXML.toString()
+              )
+          }
         }
       }
     }

--- a/src/test/scala/io/findify/s3mock/DeleteTest.scala
+++ b/src/test/scala/io/findify/s3mock/DeleteTest.scala
@@ -1,5 +1,7 @@
 package io.findify.s3mock
 
+import com.amazonaws.services.s3.model.AmazonS3Exception
+
 import scala.collection.JavaConversions._
 import scala.util.Try
 
@@ -13,6 +15,7 @@ class DeleteTest extends S3MockTest {
     s3.deleteBucket("del")
     s3.listBuckets().exists(_.getName == "del") shouldBe false
   }
+
   it should "return 404 for non existent buckets" in {
     Try(s3.deleteBucket("nodel")).isFailure shouldBe true
   }
@@ -23,7 +26,16 @@ class DeleteTest extends S3MockTest {
     s3.deleteObject("delobj", "somefile")
     s3.listObjects("delobj", "somefile").getObjectSummaries.exists(_.getKey == "somefile") shouldBe false
   }
+
   it should "return 404 for non-existent keys" in {
     Try(s3.deleteObject("nodel", "xxx")).isFailure shouldBe true
+  }
+
+  it should "produce NoSuchBucket if bucket does not exist" in {
+    val exc = intercept[AmazonS3Exception] {
+      s3.deleteBucket("aws-404")
+    }
+    exc.getStatusCode shouldBe 404
+    exc.getErrorCode shouldBe "NoSuchBucket"
   }
 }

--- a/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
 import akka.stream.ActorMaterializer
-import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.{AmazonS3Exception, ObjectMetadata}
 
 import scala.concurrent.duration._
 import scala.collection.JavaConversions._
@@ -51,4 +51,21 @@ class GetPutObjectTest extends S3MockTest {
     val result = IOUtils.toByteArray(s3.getObject("getput", "foolarge").getObjectContent)
     result shouldBe blob
   }
+
+  "get" should "produce NoSuchBucket if bucket does not exist" in {
+    val exc = intercept[AmazonS3Exception] {
+      s3.getObject("aws-404", "foo")
+    }
+    exc.getStatusCode shouldBe 404
+    exc.getErrorCode shouldBe "NoSuchBucket"
+  }
+
+  "put" should "produce NoSuchBucket if bucket does not exist" in {
+    val exc = intercept[AmazonS3Exception] {
+      s3.putObject("aws-404", "foo", "content")
+    }
+    exc.getStatusCode shouldBe 404
+    exc.getErrorCode shouldBe "NoSuchBucket"
+  }
+
 }

--- a/src/test/scala/io/findify/s3mock/ListBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketTest.scala
@@ -2,7 +2,7 @@ package io.findify.s3mock
 
 import java.util
 
-import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.amazonaws.services.s3.model.{AmazonS3Exception, S3ObjectSummary}
 
 import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
@@ -55,5 +55,13 @@ class ListBucketTest extends S3MockTest {
 
     val returnedKey = summaries.last.getKey
     s3.getObject("list4", returnedKey).getKey shouldBe "one"
+  }
+
+ it should "produce NoSuchBucket if bucket does not exist" in {
+    val exc = intercept[AmazonS3Exception] {
+      s3.listObjects("aws-404", "qaz/qax")
+    }
+    exc.getStatusCode shouldBe 404
+    exc.getErrorCode shouldBe "NoSuchBucket"
   }
 }

--- a/src/test/scala/io/findify/s3mock/awscli/GetObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/awscli/GetObjectTest.scala
@@ -33,12 +33,21 @@ class GetObjectTest extends AWSCliTest {
     val meta = s3.getObjectMetadata("awscli-head2", "foo")
     meta.getContentLength shouldBe 3
   }
-  it should "respond with status 404" in {
-    s3.createBucket("awscli-404")
+  it should "respond with status 404 if key does not exist" in {
+    s3.createBucket("awscli")
+    val exc = intercept[AmazonS3Exception] {
+      s3.getObject("awscli", "doesnotexist")
+    }
+    exc.getStatusCode shouldBe 404
+    exc.getErrorCode shouldBe "NoSuchKey"
+  }
+
+  it should "respond with status 404 if bucket does not exist" in {
+
     val exc = intercept[AmazonS3Exception] {
       s3.getObject("awscli-404", "doesnotexist")
     }
     exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchKey"
+    exc.getErrorCode shouldBe "NoSuchBucket"
   }
 }


### PR DESCRIPTION
# Problem

When I created unit tests with S3 mock I realised that **NoSuchBucket** error is not thrown when the bucket (underlying folder) does not exists in case of `getObject` and `putObject`. These calls returned with `NoSuchKey` which was misleading for me, becuase the official S3 enpoints produce `NoSuchBucket`. I wanted to created 2 separate unit tests one for `NoSuchBucket` and one for `NoSuchKey`

# Solution

Add XML representation of error message to the already existing `NoSuchBucketException` class and throw `NoSuchBucket` error if the bucket does not exist in the following cases:
- GetObject
- PutObject
- PutObjectMultipart
- ListBucket
- DeleteBucket

# Additional changes
- New unit tests for `NoSuchBucket` errors.