### PR TITLE
Enable basic object tagging support

### DIFF
--- a/src/main/scala/io/findify/s3mock/S3Mock.scala
+++ b/src/main/scala/io/findify/s3mock/S3Mock.scala
@@ -47,16 +47,18 @@ class S3Mock(port:Int, provider:Provider)(implicit system:ActorSystem = ActorSys
             CreateBucket().route(bucket),
             DeleteBucket().route(bucket)
           )
-        } ~ path(RemainingPath) { key =>
-          concat(
-            GetObject().route(bucket, key.toString()),
-            CopyObject().route(bucket, key.toString()),
-            PutObjectMultipart().route(bucket, key.toString()),
-            PutObjectMultipartStart().route(bucket, key.toString()),
-            PutObjectMultipartComplete().route(bucket, key.toString()),
-            PutObject().route(bucket, key.toString()),
-            DeleteObject().route(bucket, key.toString())
-          )
+        } ~ parameterMap { params =>
+          path(RemainingPath) { key =>
+            concat(
+              GetObject().route(bucket, key.toString(), params),
+              CopyObject().route(bucket, key.toString()),
+              PutObjectMultipart().route(bucket, key.toString()),
+              PutObjectMultipartStart().route(bucket, key.toString()),
+              PutObjectMultipartComplete().route(bucket, key.toString()),
+              PutObject().route(bucket, key.toString()),
+              DeleteObject().route(bucket, key.toString())
+            )
+          }
         }
       } ~ ListBuckets().route() ~ extractRequest { request =>
         complete {


### PR DESCRIPTION
Added a few hooks to provide some primitive support for amazon's object tagging.

Supports writing tags with a PutObjectRequest (does NOT support setObjectTagging).

Supports reading tags with getObjectTagging.

Added because I'm using (and love) s3mock to test my s3 code, but I need to test my tagging code as we're starting to use tagging to do some billing tracking.

Also I didn't bump the version number as I figured you'd want to do that if/when you merge this.