### PR TITLE
In-Memory Provider for Object and Metadata storage

### DIFF
--- a/src/main/scala/io/findify/s3mock/S3Mock.scala
+++ b/src/main/scala/io/findify/s3mock/S3Mock.scala
@@ -1,25 +1,16 @@
 package io.findify.s3mock
 
 import akka.actor.ActorSystem
-import akka.event.Logging
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
-import akka.http.scaladsl._
-import akka.http.scaladsl.model.headers.Location
-import akka.http.scaladsl.model.{HttpHeader, HttpResponse, Multipart, StatusCodes}
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
-import akka.stream.scaladsl.{Framing, Sink}
-import akka.util.ByteString
+import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.LazyLogging
-import io.findify.s3mock.error.NoSuchKeyException
-import io.findify.s3mock.provider.{FileProvider, Provider}
-import io.findify.s3mock.request.{CompleteMultipartUpload, CreateBucketConfiguration}
-import io.findify.s3mock.route.{PutObject, _}
+import io.findify.s3mock.provider.{FileProvider, InMemoryProvider, Provider}
+import io.findify.s3mock.route._
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.io.Source
-import scala.util.{Failure, Success, Try}
 /**
   * Created by shutty on 8/9/16.
   */
@@ -76,6 +67,8 @@ class S3Mock(port:Int, provider:Provider)(implicit system:ActorSystem = ActorSys
 }
 
 object S3Mock {
+  def apply(port: Int): S3Mock = new S3Mock(port, new InMemoryProvider)
   def apply(port:Int, dir:String) = new S3Mock(port, new FileProvider(dir))
+  def create(port:Int) = apply(port) // Java API
   def create(port:Int, dir:String) = apply(port, dir) // Java API
 }

--- a/src/main/scala/io/findify/s3mock/provider/InMemoryProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/InMemoryProvider.scala
@@ -1,0 +1,166 @@
+package io.findify.s3mock.provider
+
+import java.util.UUID
+
+import akka.http.scaladsl.model.DateTime
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.typesafe.scalalogging.LazyLogging
+import io.findify.s3mock.error.{NoSuchBucketException, NoSuchKeyException}
+import io.findify.s3mock.provider.metadata.{InMemoryMetadataStore, MetadataStore}
+import io.findify.s3mock.request.{CompleteMultipartUpload, CreateBucketConfiguration}
+import io.findify.s3mock.response._
+import org.apache.commons.codec.digest.DigestUtils
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.util.Random
+
+class InMemoryProvider extends Provider with LazyLogging {
+  private val mdStore = new InMemoryMetadataStore
+  private val bucketDataStore = new TrieMap[String, BucketContents]
+  private val multipartTempStore = new TrieMap[String, mutable.SortedSet[MultipartChunk]]
+
+  private case class BucketContents(creationTime: DateTime, keysInBucket: mutable.Map[String, KeyContents])
+
+  private case class KeyContents(lastModificationTime: DateTime, data: Array[Byte])
+
+  private case class MultipartChunk(partNo: Int, data: Array[Byte]) extends Ordered[MultipartChunk] {
+    override def compare(that: MultipartChunk): Int = partNo compareTo that.partNo
+  }
+
+  override def metadataStore: MetadataStore = mdStore
+
+  override def listBuckets: ListAllMyBuckets = {
+    val buckets = bucketDataStore map { case (name, data) => Bucket(name, data.creationTime) }
+    logger.debug(s"listing buckets: ${buckets.map(_.name)}")
+    ListAllMyBuckets("root", UUID.randomUUID().toString, buckets.toList)
+  }
+
+  override def listBucket(bucket: String, prefix: Option[String], delimiter: Option[String]): ListBucket = {
+    def commonPrefix(dir: String, p: String, d: String): Option[String] = {
+      dir.indexOf(d, p.length) match {
+        case -1 => None
+        case pos => Some(p + dir.substring(p.length, pos) + d)
+      }
+    }
+
+    val prefix2 = prefix.getOrElse("")
+    bucketDataStore.get(bucket) match {
+      case Some(bucketContent) =>
+        val matchingKeys = bucketContent.keysInBucket.filterKeys(_.startsWith(prefix2))
+        val matchResults = matchingKeys map { case (name, content) =>
+          Content(name, content.lastModificationTime, DigestUtils.md5Hex(content.data), content.data.length, "STANDARD")
+        }
+        logger.debug(s"listing bucket contents: ${matchResults.map(_.key)}")
+        val commonPrefixes = delimiter match {
+          case Some(del) => matchResults.flatMap(f => commonPrefix(f.key, prefix2, del)).toList.sorted.distinct
+          case None => Nil
+        }
+        val filteredFiles: List[Content] = matchResults.filterNot(f => commonPrefixes.exists(p => f.key.startsWith(p))).toList
+        ListBucket(bucket, prefix, delimiter, commonPrefixes, filteredFiles.sortBy(_.key))
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def createBucket(name: String, bucketConfig: CreateBucketConfiguration): CreateBucket = {
+    bucketDataStore.putIfAbsent(name, BucketContents(DateTime.now, new TrieMap))
+    logger.debug(s"creating bucket $name")
+    CreateBucket(name)
+  }
+
+  override def putObject(bucket: String, key: String, data: Array[Byte], objectMetadata: Option[ObjectMetadata] = None): Unit = {
+    bucketDataStore.get(bucket) match {
+      case Some(bucketContent) =>
+        logger.debug(s"putting object for s3://$bucket/$key, bytes = ${data.length}")
+        bucketContent.keysInBucket.put(key, KeyContents(DateTime.now, data))
+        objectMetadata.foreach(meta => metadataStore.put(bucket, key, meta))
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def getObject(bucket: String, key: String): GetObjectData = {
+    bucketDataStore.get(bucket) match {
+      case Some(bucketContent) => bucketContent.keysInBucket.get(key) match {
+        case Some(keyContent) =>
+          logger.debug(s"reading object for s://$bucket/$key")
+          val meta = metadataStore.get(bucket, key)
+          GetObjectData(keyContent.data, meta)
+        case None => throw NoSuchKeyException(bucket, key)
+      }
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def putObjectMultipartStart(bucket: String, key: String): InitiateMultipartUploadResult = {
+    bucketDataStore.get(bucket) match {
+      case Some(_) =>
+        val id = Math.abs(Random.nextLong()).toString
+        multipartTempStore.putIfAbsent(id, new mutable.TreeSet)
+        logger.debug(s"starting multipart upload for s3://$bucket/$key")
+        InitiateMultipartUploadResult(bucket, key, id)
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def putObjectMultipartPart(bucket: String, key: String, partNumber: Int, uploadId: String, data: Array[Byte]): Unit = {
+    bucketDataStore.get(bucket) match {
+      case Some(_) =>
+        logger.debug(s"uploading multipart chunk $partNumber for s3://$bucket/$key")
+        multipartTempStore.getOrElseUpdate(uploadId, new mutable.TreeSet).add(MultipartChunk(partNumber, data))
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def putObjectMultipartComplete(bucket: String, key: String, uploadId: String, request: CompleteMultipartUpload): CompleteMultipartUploadResult = {
+    bucketDataStore.get(bucket) match {
+      case Some(bucketContent) =>
+        val completeBytes = multipartTempStore(uploadId).toSeq.map(_.data).fold(Array[Byte]())(_ ++ _)
+        bucketContent.keysInBucket.put(key, KeyContents(DateTime.now, completeBytes))
+        multipartTempStore.remove(uploadId)
+        logger.debug(s"completed multipart upload for s3://$bucket/$key")
+        CompleteMultipartUploadResult(bucket, key, DigestUtils.md5Hex(completeBytes))
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def copyObject(sourceBucket: String, sourceKey: String, destBucket: String, destKey: String, newMeta: Option[ObjectMetadata] = None): CopyObjectResult = {
+    (bucketDataStore.get(sourceBucket), bucketDataStore.get(destBucket)) match {
+      case (Some(srcBucketContent), Some(dstBucketContent)) =>
+        srcBucketContent.keysInBucket.get(sourceKey) match {
+          case Some(srcKeyContent) =>
+            val destFileModTime = DateTime.now
+            dstBucketContent.keysInBucket.put(destKey, KeyContents(destFileModTime, srcKeyContent.data.clone))
+            logger.debug(s"Copied s3://$sourceBucket/$sourceKey to s3://$destBucket/$destKey")
+            val sourceMeta = newMeta.orElse(metadataStore.get(sourceBucket, sourceKey))
+            sourceMeta.foreach(meta => metadataStore.put(destBucket, destKey, meta))
+            CopyObjectResult(destFileModTime, DigestUtils.md5Hex(srcKeyContent.data))
+          case None => throw NoSuchKeyException(sourceBucket, sourceKey)
+        }
+      case (None, _) => throw NoSuchBucketException(sourceBucket)
+      case _ => throw NoSuchBucketException(destBucket)
+    }
+  }
+
+  override def deleteObject(bucket: String, key: String): Unit = {
+    bucketDataStore.get(bucket) match {
+      case Some(bucketContent) => bucketContent.keysInBucket.get(key) match {
+        case Some(_) =>
+          logger.debug(s"deleting object s://$bucket/$key")
+          bucketContent.keysInBucket.remove(key)
+          metadataStore.delete(bucket, key)
+        case None => throw NoSuchKeyException(bucket, key)
+      }
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+
+  override def deleteBucket(bucket: String): Unit = {
+    bucketDataStore.get(bucket) match {
+      case Some(_) =>
+        logger.debug(s"deleting bucket s://$bucket")
+        bucketDataStore.remove(bucket)
+        metadataStore.remove(bucket)
+      case None => throw NoSuchBucketException(bucket)
+    }
+  }
+}

--- a/src/main/scala/io/findify/s3mock/provider/metadata/InMemoryMetadataStore.scala
+++ b/src/main/scala/io/findify/s3mock/provider/metadata/InMemoryMetadataStore.scala
@@ -1,0 +1,27 @@
+package io.findify.s3mock.provider.metadata
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+
+class InMemoryMetadataStore extends MetadataStore {
+
+  private val bucketMetadata = new TrieMap[String, mutable.Map[String, ObjectMetadata]]
+
+  override def put(bucket: String, key: String, meta: ObjectMetadata): Unit = {
+    val currentBucketMetadata = bucketMetadata.getOrElseUpdate(bucket, new TrieMap[String, ObjectMetadata]())
+    currentBucketMetadata.put(key, meta)
+  }
+
+  override def get(bucket: String, key: String): Option[ObjectMetadata] = {
+    bucketMetadata.get(bucket).flatMap(_.get(key))
+  }
+
+  override def delete(bucket: String, key: String): Unit = {
+    val currentBucketMetadata = bucketMetadata.get(bucket)
+    currentBucketMetadata.flatMap(_.remove(key))
+  }
+
+  override def remove(bucket: String): Unit = bucketMetadata.remove(bucket)
+}

--- a/src/test/scala/io/findify/s3mock/CopyObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/CopyObjectTest.scala
@@ -10,45 +10,48 @@ import com.amazonaws.services.s3.model.{CopyObjectRequest, ObjectMetadata, PutOb
   * Created by shutty on 3/13/17.
   */
 class CopyObjectTest extends S3MockTest {
-  "object" should "be copied even if destdir does not exist" in {
-    s3.createBucket("bucket-1")
-    s3.createBucket("bucket-2")
-    s3.putObject("bucket-1", "test.txt", "contents")
-    s3.copyObject("bucket-1", "test.txt", "bucket-2", "folder/test.txt")
-    getContent(s3.getObject("bucket-2", "folder/test.txt")) shouldBe "contents"
-  }
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    it should "copy an object even if destdir does not exist" in {
+      s3.createBucket("bucket-1")
+      s3.createBucket("bucket-2")
+      s3.putObject("bucket-1", "test.txt", "contents")
+      s3.copyObject("bucket-1", "test.txt", "bucket-2", "folder/test.txt")
+      getContent(s3.getObject("bucket-2", "folder/test.txt")) shouldBe "contents"
+    }
 
-  it should "be copied with metadata" in {
-    s3.createBucket("bucket-3")
-    val meta = new ObjectMetadata()
-    val user = new util.HashMap[String,String]()
-    user.put("a", "b")
-    meta.setUserMetadata(user)
-    val req = new PutObjectRequest("bucket-3", "test.txt", new ByteArrayInputStream(Array(61.toByte, 62.toByte, 63.toByte)), meta)
-    s3.putObject(req)
-    s3.copyObject("bucket-3", "test.txt", "bucket-3", "test2.txt")
-    val obj = s3.getObject("bucket-3", "test2.txt")
-    obj.getObjectMetadata.getUserMetadata.get("a") shouldBe "b"
-  }
+    it should "copy an object with metadata" in {
+      s3.createBucket("bucket-3")
+      val meta = new ObjectMetadata()
+      val user = new util.HashMap[String, String]()
+      user.put("a", "b")
+      meta.setUserMetadata(user)
+      val req = new PutObjectRequest("bucket-3", "test.txt", new ByteArrayInputStream(Array(61.toByte, 62.toByte, 63.toByte)), meta)
+      s3.putObject(req)
+      s3.copyObject("bucket-3", "test.txt", "bucket-3", "test2.txt")
+      val obj = s3.getObject("bucket-3", "test2.txt")
+      obj.getObjectMetadata.getUserMetadata.get("a") shouldBe "b"
+    }
 
-  it should "be copied with new metadata" in {
-    s3.createBucket("test-bucket")
+    it should "copy an object with new metadata" in {
+      s3.createBucket("test-bucket")
 
-    val meta = new ObjectMetadata
-    meta.addUserMetadata("key1", "value1")
-    meta.addUserMetadata("key2", "value2")
-    val putRequest = new PutObjectRequest("test-bucket", "test.txt", new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), meta)
-    s3.putObject(putRequest)
+      val meta = new ObjectMetadata
+      meta.addUserMetadata("key1", "value1")
+      meta.addUserMetadata("key2", "value2")
+      val putRequest = new PutObjectRequest("test-bucket", "test.txt", new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), meta)
+      s3.putObject(putRequest)
 
-    val newMeta = new ObjectMetadata
-    newMeta.addUserMetadata("new-key1", "new-value1")
-    newMeta.addUserMetadata("new-key2", "new-value2")
-    val copyRequest = new CopyObjectRequest("test-bucket", "test.txt", "test-bucket", "test2.txt").withNewObjectMetadata(newMeta)
-    s3.copyObject(copyRequest)
+      val newMeta = new ObjectMetadata
+      newMeta.addUserMetadata("new-key1", "new-value1")
+      newMeta.addUserMetadata("new-key2", "new-value2")
+      val copyRequest = new CopyObjectRequest("test-bucket", "test.txt", "test-bucket", "test2.txt").withNewObjectMetadata(newMeta)
+      s3.copyObject(copyRequest)
 
-    val obj = s3.getObject("test-bucket", "test2.txt")
-    obj.getObjectMetadata.getUserMetadata.size shouldBe 2
-    obj.getObjectMetadata.getUserMetadata.get("new-key1") shouldBe "new-value1"
-    obj.getObjectMetadata.getUserMetadata.get("new-key2") shouldBe "new-value2"
+      val obj = s3.getObject("test-bucket", "test2.txt")
+      obj.getObjectMetadata.getUserMetadata.size shouldBe 2
+      obj.getObjectMetadata.getUserMetadata.get("new-key1") shouldBe "new-value1"
+      obj.getObjectMetadata.getUserMetadata.get("new-key2") shouldBe "new-value2"
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/DeleteTest.scala
+++ b/src/test/scala/io/findify/s3mock/DeleteTest.scala
@@ -9,42 +9,46 @@ import scala.util.Try
   * Created by shutty on 8/11/16.
   */
 class DeleteTest extends S3MockTest {
-  "bucket" should "be deleted" in {
-    s3.createBucket("del")
-    s3.listBuckets().exists(_.getName == "del") shouldBe true
-    s3.deleteBucket("del")
-    s3.listBuckets().exists(_.getName == "del") shouldBe false
-  }
-
-  it should "return 404 for non existent buckets" in {
-    Try(s3.deleteBucket("nodel")).isFailure shouldBe true
-  }
-  "object" should "be deleted" in {
-    s3.createBucket("delobj")
-    s3.putObject("delobj", "somefile", "foo")
-    s3.listObjects("delobj", "somefile").getObjectSummaries.exists(_.getKey == "somefile") shouldBe true
-    s3.deleteObject("delobj", "somefile")
-    s3.listObjects("delobj", "somefile").getObjectSummaries.exists(_.getKey == "somefile") shouldBe false
-  }
-
-  it should "return 404 for non-existent keys" in {
-    Try(s3.deleteObject("nodel", "xxx")).isFailure shouldBe true
-  }
-
-  it should "produce NoSuchBucket if bucket does not exist" in {
-    val exc = intercept[AmazonS3Exception] {
-      s3.deleteBucket("aws-404")
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    it should "delete a bucket" in {
+      s3.createBucket("del")
+      s3.listBuckets().exists(_.getName == "del") shouldBe true
+      s3.deleteBucket("del")
+      s3.listBuckets().exists(_.getName == "del") shouldBe false
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchBucket"
-  }
 
-  it should "delete multiple objects at once" in {
-    s3.createBucket("delobj2")
-    s3.putObject("delobj2", "somefile1", "foo1")
-    s3.putObject("delobj2", "somefile2", "foo2")
-    s3.listObjects("delobj2", "somefile").getObjectSummaries.size() shouldBe 2
-    s3.deleteObjects(new DeleteObjectsRequest("delobj2").withKeys("somefile1", "somefile2"))
-    s3.listObjects("delobj2", "somefile").getObjectSummaries.size() shouldBe 0
+    it should "return 404 for non existent buckets when deleting" in {
+      Try(s3.deleteBucket("nodel")).isFailure shouldBe true
+    }
+
+    it should "delete an object" in {
+      s3.createBucket("delobj")
+      s3.putObject("delobj", "somefile", "foo")
+      s3.listObjects("delobj", "somefile").getObjectSummaries.exists(_.getKey == "somefile") shouldBe true
+      s3.deleteObject("delobj", "somefile")
+      s3.listObjects("delobj", "somefile").getObjectSummaries.exists(_.getKey == "somefile") shouldBe false
+    }
+
+    it should "return 404 for non-existent keys when deleting" in {
+      Try(s3.deleteObject("nodel", "xxx")).isFailure shouldBe true
+    }
+
+    it should "produce NoSuchBucket if bucket does not exist when deleting" in {
+      val exc = intercept[AmazonS3Exception] {
+        s3.deleteBucket("aws-404")
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchBucket"
+    }
+
+    it should "delete multiple objects at once" in {
+      s3.createBucket("delobj2")
+      s3.putObject("delobj2", "somefile1", "foo1")
+      s3.putObject("delobj2", "somefile2", "foo2")
+      s3.listObjects("delobj2", "somefile").getObjectSummaries.size() shouldBe 2
+      s3.deleteObjects(new DeleteObjectsRequest("delobj2").withKeys("somefile1", "somefile2"))
+      s3.listObjects("delobj2", "somefile").getObjectSummaries.size() shouldBe 0
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
@@ -9,98 +9,104 @@ import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
 import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.model._
 
-import scala.concurrent.duration._
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 import scala.util.Random
 
 /**
   * Created by shutty on 8/10/16.
   */
+
 class GetPutObjectTest extends S3MockTest {
-  "s3 mock" should "put object" in {
-    s3.createBucket("getput").getName shouldBe "getput"
-    s3.listBuckets().exists(_.getName == "getput") shouldBe true
-    s3.putObject("getput", "foo", "bar")
-    val result = getContent(s3.getObject("getput", "foo"))
-    result shouldBe "bar"
-  }
-  it should "be able to post data" in {
-    implicit val system = ActorSystem.create("test")
-    implicit val mat = ActorMaterializer()
-    val http = Http(system)
-    if (!s3.listBuckets().exists(_.getName == "getput")) s3.createBucket("getput")
-    val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = "http://127.0.0.1:8001/getput/foo2", entity = "bar")), 10.seconds)
-    getContent(s3.getObject("getput", "foo2")) shouldBe "bar"
-  }
-  it should "put objects in subdirs" in {
-    s3.putObject("getput", "foo1/foo2/foo3", "bar")
-    val result = getContent(s3.getObject("getput", "foo1/foo2/foo3"))
-    result shouldBe "bar"
-  }
-  it should "not drop \\r\\n symbols" in {
-    s3.putObject("getput", "foorn", "bar\r\nbaz")
-    val result = getContent(s3.getObject("getput", "foorn"))
-    result shouldBe "bar\r\nbaz"
-  }
-  it should "put & get large binary blobs" in {
-    val blob = Random.nextString(1024000).getBytes("UTF-8")
-    s3.putObject("getput", "foolarge", new ByteArrayInputStream(blob), new ObjectMetadata())
-    val result = getContent(s3.getObject("getput", "foolarge")).getBytes("UTF-8")
-    result shouldBe blob
-  }
-
-  "tagging" should "store tags and spit them back on get tagging requests" in {
-    s3.createBucket("tbucket")
-    s3.putObject(
-      new PutObjectRequest("tbucket", "taggedobj", new ByteArrayInputStream("content".getBytes("UTF-8")), new ObjectMetadata)
-        .withTagging(new ObjectTagging(List(new Tag("key1", "val1"), new Tag("key=&interesting", "value=something&stragne"))))
-    )
-    var tagging = s3.getObjectTagging(new GetObjectTaggingRequest("tbucket", "taggedobj")).getTagSet
-    var tagMap = new util.HashMap[String, String]()
-    for (tag <- tagging){
-      tagMap.put(tag.getKey, tag.getValue)
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    val port = fixture.port
+    it should "put object" in {
+      s3.createBucket("getput").getName shouldBe "getput"
+      s3.listBuckets().exists(_.getName == "getput") shouldBe true
+      s3.putObject("getput", "foo", "bar")
+      val result = getContent(s3.getObject("getput", "foo"))
+      result shouldBe "bar"
     }
-    tagMap.size() shouldBe 2
-    tagMap.get("key1") shouldBe "val1"
-    tagMap.get("key=&interesting") shouldBe "value=something&stragne"
-  }
-  it should "be OK with retrieving tags for un-tagged objects" in {
-    s3.putObject("tbucket", "taggedobj", "some-content")
-    var tagging = s3.getObjectTagging(new GetObjectTaggingRequest("tbucket", "taggedobj")).getTagSet
-    tagging.size() shouldBe 0
-  }
-
-  "get" should "produce NoSuchBucket if bucket does not exist" in {
-    val exc = intercept[AmazonS3Exception] {
-      s3.getObject("aws-404", "foo")
+    it should "be able to post data" in {
+      implicit val system = ActorSystem.create("test")
+      implicit val mat = ActorMaterializer()
+      val http = Http(system)
+      if (!s3.listBuckets().exists(_.getName == "getput")) s3.createBucket("getput")
+      val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:$port/getput/foo2", entity = "bar")), 10.seconds)
+      getContent(s3.getObject("getput", "foo2")) shouldBe "bar"
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchBucket"
-  }
-
-  "put" should "produce NoSuchBucket if bucket does not exist" in {
-    val exc = intercept[AmazonS3Exception] {
-      s3.putObject("aws-404", "foo", "content")
+    it should "put objects in subdirs" in {
+      s3.putObject("getput", "foo1/foo2/foo3", "bar")
+      val result = getContent(s3.getObject("getput", "foo1/foo2/foo3"))
+      result shouldBe "bar"
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchBucket"
-  }
+    it should "not drop \\r\\n symbols" in {
+      s3.putObject("getput", "foorn", "bar\r\nbaz")
+      val result = getContent(s3.getObject("getput", "foorn"))
+      result shouldBe "bar\r\nbaz"
+    }
+    it should "put & get large binary blobs" in {
+      val blob = Random.nextString(1024000).getBytes("UTF-8")
+      s3.putObject("getput", "foolarge", new ByteArrayInputStream(blob), new ObjectMetadata())
+      val result = getContent(s3.getObject("getput", "foolarge")).getBytes("UTF-8")
+      result shouldBe blob
+    }
 
-  it should "work with large files" in {
-    val huge = Random.nextString(10*1024*1024)
-    s3.putObject("getput", "foobig", huge)
-    val result = getContent(s3.getObject("getput", "foobig"))
-    result shouldBe huge
-  }
+    it should "store tags and spit them back on get tagging requests" in {
+      s3.createBucket("tbucket")
+      s3.putObject(
+        new PutObjectRequest("tbucket", "taggedobj", new ByteArrayInputStream("content".getBytes("UTF-8")), new ObjectMetadata)
+          .withTagging(new ObjectTagging(List(new Tag("key1", "val1"), new Tag("key=&interesting", "value=something&stragne"))))
+      )
+      var tagging = s3.getObjectTagging(new GetObjectTaggingRequest("tbucket", "taggedobj")).getTagSet
+      var tagMap = new util.HashMap[String, String]()
+      for (tag <- tagging) {
+        tagMap.put(tag.getKey, tag.getValue)
+      }
+      tagMap.size() shouldBe 2
+      tagMap.get("key1") shouldBe "val1"
+      tagMap.get("key=&interesting") shouldBe "value=something&stragne"
+    }
+    it should "be OK with retrieving tags for un-tagged objects" in {
+      s3.putObject("tbucket", "taggedobj", "some-content")
+      var tagging = s3.getObjectTagging(new GetObjectTaggingRequest("tbucket", "taggedobj")).getTagSet
+      tagging.size() shouldBe 0
+    }
 
-  it should "work with dot-files" in {
-    s3.createBucket("dot")
-    s3.listBuckets().exists(_.getName == "dot") shouldBe true
-    s3.putObject("dot", "foo", "bar")
-    s3.putObject("dot", ".foo", "bar")
-    val result = s3.listObjects("dot").getObjectSummaries.toList.map(_.getKey)
-    result shouldBe List(".foo", "foo")
+    it should "produce NoSuchBucket if bucket does not exist when GETting" in {
+      val exc = intercept[AmazonS3Exception] {
+        s3.getObject("aws-404", "foo")
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchBucket"
+    }
+
+    it should "produce NoSuchBucket if bucket does not exist when PUTting" in {
+      val exc = intercept[AmazonS3Exception] {
+        s3.putObject("aws-404", "foo", "content")
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchBucket"
+    }
+
+    it should "work with large files" in {
+      val huge = Random.nextString(10 * 1024 * 1024)
+      s3.putObject("getput", "foobig", huge)
+      val result = getContent(s3.getObject("getput", "foobig"))
+      result shouldBe huge
+    }
+
+    it should "work with dot-files" in {
+      s3.createBucket("dot")
+      s3.listBuckets().exists(_.getName == "dot") shouldBe true
+      s3.putObject("dot", "foo", "bar")
+      s3.putObject("dot", ".foo", "bar")
+      val result = s3.listObjects("dot").getObjectSummaries.toList.map(_.getKey)
+      result shouldBe List(".foo", "foo")
+    }
   }
 
 }
+

--- a/src/test/scala/io/findify/s3mock/GetPutObjectWithMetadataTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectWithMetadataTest.scala
@@ -10,57 +10,59 @@ import scala.collection.JavaConversions._
   * Created by shutty on 8/10/16.
   */
 class GetPutObjectWithMetadataTest extends S3MockTest {
-  "s3 mock" should "put object with metadata" in {
-    s3.createBucket("getput").getName shouldBe "getput"
-    s3.listBuckets().exists(_.getName == "getput") shouldBe true
+  override def behaviour(fixture: => Fixture): Unit = {
+    val s3 = fixture.client
+    it should "put object with metadata" in {
+      s3.createBucket("getput").getName shouldBe "getput"
+      s3.listBuckets().exists(_.getName == "getput") shouldBe true
 
-    val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
-    val metadata: ObjectMetadata = new ObjectMetadata()
-    metadata.setContentType("application/json")
-    metadata.setUserMetadata(Map("metamaic" -> "maic"))
+      val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
+      val metadata: ObjectMetadata = new ObjectMetadata()
+      metadata.setContentType("application/json")
+      metadata.setUserMetadata(Map("metamaic" -> "maic"))
 
-    s3.putObject("getput", "foo", is, metadata)
+      s3.putObject("getput", "foo", is, metadata)
 
-    val s3Object: S3Object = s3.getObject("getput", "foo")
-    val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
-    actualMetadata.getContentType shouldBe "application/json"
+      val s3Object: S3Object = s3.getObject("getput", "foo")
+      val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
+      actualMetadata.getContentType shouldBe "application/json"
 
-    getContent(s3Object) shouldBe "bar"
+      getContent(s3Object) shouldBe "bar"
+    }
+
+    it should "put object with metadata, but skip unvalid content-type" in {
+      s3.createBucket("getput").getName shouldBe "getput"
+      s3.listBuckets().exists(_.getName == "getput") shouldBe true
+
+      val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
+      val metadata: ObjectMetadata = new ObjectMetadata()
+      metadata.setContentType("application")
+      metadata.setUserMetadata(Map("metamaic" -> "maic"))
+
+      s3.putObject("getput", "foo", is, metadata)
+
+      val s3Object: S3Object = s3.getObject("getput", "foo")
+      val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
+      actualMetadata.getContentType shouldBe "application/octet-stream"
+
+      getContent(s3Object) shouldBe "bar"
+    }
+    it should "put object in subdirs with metadata, but skip unvalid content-type" in {
+      s3.createBucket("getput").getName shouldBe "getput"
+      s3.listBuckets().exists(_.getName == "getput") shouldBe true
+
+      val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
+      val metadata: ObjectMetadata = new ObjectMetadata()
+      metadata.setContentType("application")
+      metadata.setUserMetadata(Map("metamaic" -> "maic"))
+
+      s3.putObject("getput", "foo1/bar", is, metadata)
+
+      val s3Object: S3Object = s3.getObject("getput", "foo1/bar")
+      val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
+      actualMetadata.getContentType shouldBe "application/octet-stream"
+
+      getContent(s3Object) shouldBe "bar"
+    }
   }
-
-  "s3 mock" should "put object with metadata, but skip unvalid content-type" in {
-    s3.createBucket("getput").getName shouldBe "getput"
-    s3.listBuckets().exists(_.getName == "getput") shouldBe true
-
-    val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
-    val metadata: ObjectMetadata = new ObjectMetadata()
-    metadata.setContentType("application")
-    metadata.setUserMetadata(Map("metamaic" -> "maic"))
-
-    s3.putObject("getput", "foo", is, metadata)
-
-    val s3Object: S3Object = s3.getObject("getput", "foo")
-    val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
-    actualMetadata.getContentType shouldBe "application/octet-stream"
-
-    getContent(s3Object) shouldBe "bar"
-  }
-  "s3 mock" should "put object in subdirs with metadata, but skip unvalid content-type" in {
-    s3.createBucket("getput").getName shouldBe "getput"
-    s3.listBuckets().exists(_.getName == "getput") shouldBe true
-
-    val is = new ByteArrayInputStream("bar".getBytes("UTF-8"))
-    val metadata: ObjectMetadata = new ObjectMetadata()
-    metadata.setContentType("application")
-    metadata.setUserMetadata(Map("metamaic" -> "maic"))
-
-    s3.putObject("getput", "foo1/bar", is, metadata)
-
-    val s3Object: S3Object = s3.getObject("getput", "foo1/bar")
-    val actualMetadata: ObjectMetadata = s3Object.getObjectMetadata
-    actualMetadata.getContentType shouldBe "application/octet-stream"
-
-    getContent(s3Object) shouldBe "bar"
-  }
-
 }

--- a/src/test/scala/io/findify/s3mock/JavaExampleTest.scala
+++ b/src/test/scala/io/findify/s3mock/JavaExampleTest.scala
@@ -1,51 +1,34 @@
 package io.findify.s3mock
 
-import java.util.UUID
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
 
 import scala.collection.JavaConversions._
-import better.files.File
-import com.amazonaws.auth.{AnonymousAWSCredentials, BasicAWSCredentials}
-import com.amazonaws.services.s3.AmazonS3Client
-import io.findify.s3mock.provider.FileProvider
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
-
 import scala.io.Source
 
 /**
   * Created by shutty on 8/19/16.
   */
-class JavaExampleTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-  val s3 = new AmazonS3Client(new AnonymousAWSCredentials())
-  s3.setEndpoint("http://127.0.0.1:8001")
+class JavaExampleTest extends S3MockTest {
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    val port = fixture.port
+    it should "upload files with anonymous credentials" in {
+      s3.createBucket("getput").getName shouldBe "getput"
+      s3.listBuckets().exists(_.getName == "getput") shouldBe true
+      s3.putObject("getput", "foo", "bar")
+      val result = Source.fromInputStream(s3.getObject("getput", "foo").getObjectContent, "UTF-8").mkString
+      result shouldBe "bar"
+    }
 
-  val workDir = s"/tmp/${UUID.randomUUID()}"
-  val server = new S3Mock(8001, new FileProvider(workDir))
+    it should "upload files with basic credentials" in {
+      val s3b = new AmazonS3Client(new BasicAWSCredentials("foo", "bar"))
+      s3b.setEndpoint(s"http://127.0.0.1:$port")
+      s3b.putObject("getput", "foo2", "bar2")
+      val result = Source.fromInputStream(s3b.getObject("getput", "foo2").getObjectContent, "UTF-8").mkString
+      result shouldBe "bar2"
 
-  override def beforeAll = {
-    if (!File(workDir).exists) File(workDir).createDirectory()
-    server.start
-  }
-
-  override def afterAll = {
-    server.stop
-    File(workDir).delete()
-  }
-
-  "java example" should "upload files with anonymous credentials" in {
-    s3.createBucket("getput").getName shouldBe "getput"
-    s3.listBuckets().exists(_.getName == "getput") shouldBe true
-    s3.putObject("getput", "foo", "bar")
-    val result = Source.fromInputStream(s3.getObject("getput", "foo").getObjectContent, "UTF-8").mkString
-    result shouldBe "bar"
-  }
-
-  it should "upload files with basic credentials" in {
-    val s3b = new AmazonS3Client(new BasicAWSCredentials("foo", "bar"))
-    s3b.setEndpoint("http://127.0.0.1:8001")
-    s3b.putObject("getput", "foo2", "bar2")
-    val result = Source.fromInputStream(s3b.getObject("getput", "foo2").getObjectContent, "UTF-8").mkString
-    result shouldBe "bar2"
-
+    }
   }
 }
 

--- a/src/test/scala/io/findify/s3mock/ListBucketEmptyWorkdirTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketEmptyWorkdirTest.scala
@@ -1,37 +1,19 @@
 package io.findify.s3mock
 
-import java.util.UUID
-
 import scala.collection.JavaConverters._
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
-import io.findify.s3mock.provider.FileProvider
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 /**
   * Created by shutty on 8/30/16.
   */
-class ListBucketEmptyWorkdirTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-  lazy val s3 = new AmazonS3Client(new BasicAWSCredentials("hello", "world"))
-
-  val workDir = s"/tmp/${UUID.randomUUID()}"
-  lazy val server = new S3Mock(8001, new FileProvider(workDir))
-
-  override def beforeAll = {
-    s3.setEndpoint("http://127.0.0.1:8001")
-    server.start
+class ListBucketEmptyWorkdirTest extends S3MockTest {
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    it should "list bucket with empty prefix" in {
+      s3.createBucket("list")
+      s3.putObject("list", "foo1", "xxx")
+      s3.putObject("list", "foo2", "xxx")
+      val list = s3.listObjects("list").getObjectSummaries.asScala.toList
+      list.map(_.getKey).forall(_.startsWith("foo")) shouldBe true
+    }
   }
-  override def afterAll = {
-    server.stop
-  }
-
-  "s3mock" should "list bucket with empty prefix" in {
-    s3.createBucket("list")
-    s3.putObject("list", "foo1", "xxx")
-    s3.putObject("list", "foo2", "xxx")
-    val list = s3.listObjects("list").getObjectSummaries.asScala.toList
-    list.map(_.getKey).forall(_.startsWith("foo")) shouldBe true
-  }
-
-
 }

--- a/src/test/scala/io/findify/s3mock/ListBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketTest.scala
@@ -5,139 +5,142 @@ import java.util
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.{AmazonS3Exception, ListObjectsRequest, S3ObjectSummary}
 
-import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
   * Created by shutty on 8/9/16.
   */
 class ListBucketTest extends S3MockTest {
-  "s3 mock" should "list bucket" in {
-    s3.createBucket("foo")
-    s3.listObjects("foo").getObjectSummaries.isEmpty shouldBe true
-  }
-  it should "list bucket with prefix" in {
-    s3.createBucket("list")
-    s3.putObject("list", "foo1", "xxx")
-    s3.putObject("list", "foo2", "xxx")
-    s3.putObject("list", "xfoo3", "xxx")
-    val list = s3.listObjects("list", "foo").getObjectSummaries.asScala.toList
-    list.map(_.getKey).forall(_.startsWith("foo")) shouldBe true
-  }
-  it should "list objects in subfolders with prefix" in {
-    s3.createBucket("list2")
-    s3.putObject("list2", "one/foo1/1", "xxx")
-    s3.putObject("list2", "one/foo2/2", "xxx")
-    s3.putObject("list2", "one/foo2/3", "xxx")
-    s3.putObject("list2", "one/foo2/4", "xxx")
-    s3.putObject("list2", "one/xfoo3", "xxx")
-    val ol = s3.listObjects("list2", "one/f").getObjectSummaries.asScala.toList
-    ol.size shouldBe 4
-    ol.map(_.getKey).forall(_.startsWith("one/foo")) shouldBe true
-  }
-  it should "return empty list if prefix is incorrect" in {
-    s3.createBucket("list3")
-    s3.putObject("list3", "one/foo1", "xxx")
-    s3.putObject("list3", "one/foo2", "xxx")
-    s3.putObject("list3", "one/xfoo3", "xxx")
-    s3.listObjects("list3", "qaz/qax").getObjectSummaries.asScala.isEmpty shouldBe true
-
-  }
-  it should "return keys with valid keys (when no prefix given)" in {
-    s3.createBucket("list4")
-    s3.putObject("list4", "one", "xxx")
-    val summaries: util.List[S3ObjectSummary] = s3.listObjects("list4").getObjectSummaries
-    summaries.size() shouldBe 1
-    val summary = summaries.get(0)
-    summary.getBucketName shouldBe "list4"
-    summary.getKey shouldBe "one"
-    summary.getSize shouldBe 3
-    summary.getStorageClass shouldBe "STANDARD"
-
-    val returnedKey = summaries.last.getKey
-    s3.getObject("list4", returnedKey).getKey shouldBe "one"
-  }
-
- it should "produce NoSuchBucket if bucket does not exist" in {
-    val exc = intercept[AmazonS3Exception] {
-      s3.listObjects("aws-404", "qaz/qax")
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    it should "list bucket" in {
+      s3.createBucket("foo")
+      s3.listObjects("foo").getObjectSummaries.isEmpty shouldBe true
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchBucket"
-  }
+    it should "list bucket with prefix" in {
+      s3.createBucket("list")
+      s3.putObject("list", "foo1", "xxx")
+      s3.putObject("list", "foo2", "xxx")
+      s3.putObject("list", "xfoo3", "xxx")
+      val list = s3.listObjects("list", "foo").getObjectSummaries.asScala.toList
+      list.map(_.getKey).forall(_.startsWith("foo")) shouldBe true
+    }
+    it should "list objects in subfolders with prefix" in {
+      s3.createBucket("list2")
+      s3.putObject("list2", "one/foo1/1", "xxx")
+      s3.putObject("list2", "one/foo2/2", "xxx")
+      s3.putObject("list2", "one/foo2/3", "xxx")
+      s3.putObject("list2", "one/foo2/4", "xxx")
+      s3.putObject("list2", "one/xfoo3", "xxx")
+      val ol = s3.listObjects("list2", "one/f").getObjectSummaries.asScala.toList
+      ol.size shouldBe 4
+      ol.map(_.getKey).forall(_.startsWith("one/foo")) shouldBe true
+    }
+    it should "return empty list if prefix is incorrect" in {
+      s3.createBucket("list3")
+      s3.putObject("list3", "one/foo1", "xxx")
+      s3.putObject("list3", "one/foo2", "xxx")
+      s3.putObject("list3", "one/xfoo3", "xxx")
+      s3.listObjects("list3", "qaz/qax").getObjectSummaries.asScala.isEmpty shouldBe true
 
-  it should "obey delimiters && prefixes v1" in {
-    s3.createBucket("list5")
-    s3.putObject("list5", "sample.jpg", "xxx")
-    s3.putObject("list5", "photos/2006/January/sample.jpg", "yyy")
-    s3.putObject("list5", "photos/2006/February/sample2.jpg", "zzz")
-    s3.putObject("list5", "photos/2006/February/sample3.jpg", "zzz")
-    s3.putObject("list5", "photos/2006/February/sample4.jpg", "zzz")
-    val req1 = new ListObjectsRequest()
-    req1.setBucketName("list5")
-    req1.setDelimiter("/")
-    val list1  = s3.listObjects(req1)
-    val summaries1 = list1.getObjectSummaries.map(_.getKey).toList
-    list1.getCommonPrefixes.asScala.toList shouldBe List("photos/")
-    summaries1 shouldBe List("sample.jpg")
-  }
-  it should "obey delimiters && prefixes v2" in {
-    s3.createBucket("list5")
-    s3.putObject("list5", "sample.jpg", "xxx")
-    s3.putObject("list5", "photos/2006/January/sample.jpg", "yyy")
-    s3.putObject("list5", "photos/2006/February/sample2.jpg", "zzz")
-    s3.putObject("list5", "photos/2006/February/sample3.jpg", "zzz")
-    s3.putObject("list5", "photos/2006/February/sample4.jpg", "zzz")
-    val req2 = new ListObjectsRequest()
-    req2.setBucketName("list5")
-    req2.setDelimiter("/")
-    req2.setPrefix("photos/2006/")
-    val list2  = s3.listObjects(req2)
-    val summaries2 = list2.getObjectSummaries.map(_.getKey).toList
-    list2.getCommonPrefixes.asScala.toList shouldBe List("photos/2006/February/", "photos/2006/January/")
-    summaries2 shouldBe Nil
-  }
+    }
+    it should "return keys with valid keys (when no prefix given)" in {
+      s3.createBucket("list4")
+      s3.putObject("list4", "one", "xxx")
+      val summaries: util.List[S3ObjectSummary] = s3.listObjects("list4").getObjectSummaries
+      summaries.size() shouldBe 1
+      val summary = summaries.get(0)
+      summary.getBucketName shouldBe "list4"
+      summary.getKey shouldBe "one"
+      summary.getSize shouldBe 3
+      summary.getStorageClass shouldBe "STANDARD"
 
-  it should "obey delimiters && prefixes v2 (matching real s3)" ignore {
-    val s3 = AmazonS3ClientBuilder.defaultClient()
-    s3.createBucket("findify-merlin")
-    s3.putObject("findify-merlin", "sample.jpg", "xxx")
-    s3.putObject("findify-merlin", "photos/2006/January/sample.jpg", "yyy")
-    s3.putObject("findify-merlin", "photos/2006/February/sample2.jpg", "zzz")
-    s3.putObject("findify-merlin", "photos/2006/February/sample3.jpg", "zzz")
-    s3.putObject("findify-merlin", "photos/2006/February/sample4.jpg", "zzz")
-    val req2 = new ListObjectsRequest()
-    req2.setBucketName("findify-merlin")
-    req2.setDelimiter("/")
-    req2.setPrefix("photos/")
-    val list2  = s3.listObjects(req2)
-    val summaries2 = list2.getObjectSummaries.map(_.getKey).toList
-    list2.getCommonPrefixes.asScala.toList shouldBe List("photos/2006/")
-    summaries2 shouldBe Nil
-  }
+      val returnedKey = summaries.last.getKey
+      s3.getObject("list4", returnedKey).getKey shouldBe "one"
+    }
+
+    it should "produce NoSuchBucket if bucket does not exist" in {
+      val exc = intercept[AmazonS3Exception] {
+        s3.listObjects("aws-404", "qaz/qax")
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchBucket"
+    }
+
+    it should "obey delimiters && prefixes v1" in {
+      s3.createBucket("list5")
+      s3.putObject("list5", "sample.jpg", "xxx")
+      s3.putObject("list5", "photos/2006/January/sample.jpg", "yyy")
+      s3.putObject("list5", "photos/2006/February/sample2.jpg", "zzz")
+      s3.putObject("list5", "photos/2006/February/sample3.jpg", "zzz")
+      s3.putObject("list5", "photos/2006/February/sample4.jpg", "zzz")
+      val req1 = new ListObjectsRequest()
+      req1.setBucketName("list5")
+      req1.setDelimiter("/")
+      val list1 = s3.listObjects(req1)
+      val summaries1 = list1.getObjectSummaries.map(_.getKey).toList
+      list1.getCommonPrefixes.asScala.toList shouldBe List("photos/")
+      summaries1 shouldBe List("sample.jpg")
+    }
+    it should "obey delimiters && prefixes v2" in {
+      s3.createBucket("list5")
+      s3.putObject("list5", "sample.jpg", "xxx")
+      s3.putObject("list5", "photos/2006/January/sample.jpg", "yyy")
+      s3.putObject("list5", "photos/2006/February/sample2.jpg", "zzz")
+      s3.putObject("list5", "photos/2006/February/sample3.jpg", "zzz")
+      s3.putObject("list5", "photos/2006/February/sample4.jpg", "zzz")
+      val req2 = new ListObjectsRequest()
+      req2.setBucketName("list5")
+      req2.setDelimiter("/")
+      req2.setPrefix("photos/2006/")
+      val list2 = s3.listObjects(req2)
+      val summaries2 = list2.getObjectSummaries.map(_.getKey).toList
+      list2.getCommonPrefixes.asScala.toList shouldBe List("photos/2006/February/", "photos/2006/January/")
+      summaries2 shouldBe Nil
+    }
+
+    it should "obey delimiters && prefixes v2 (matching real s3)" ignore {
+      val s3 = AmazonS3ClientBuilder.defaultClient()
+      s3.createBucket("findify-merlin")
+      s3.putObject("findify-merlin", "sample.jpg", "xxx")
+      s3.putObject("findify-merlin", "photos/2006/January/sample.jpg", "yyy")
+      s3.putObject("findify-merlin", "photos/2006/February/sample2.jpg", "zzz")
+      s3.putObject("findify-merlin", "photos/2006/February/sample3.jpg", "zzz")
+      s3.putObject("findify-merlin", "photos/2006/February/sample4.jpg", "zzz")
+      val req2 = new ListObjectsRequest()
+      req2.setBucketName("findify-merlin")
+      req2.setDelimiter("/")
+      req2.setPrefix("photos/")
+      val list2 = s3.listObjects(req2)
+      val summaries2 = list2.getObjectSummaries.map(_.getKey).toList
+      list2.getCommonPrefixes.asScala.toList shouldBe List("photos/2006/")
+      summaries2 shouldBe Nil
+    }
 
 
-  it should "obey delimiters && prefixes v3" in {
-    s3.createBucket("list5")
-    s3.putObject("list5", "dev/someEvent/2017/03/13/00/_SUCCESS", "xxx")
-    s3.putObject("list5", "dev/someEvent/2017/03/13/01/_SUCCESS", "yyy")
-    s3.putObject("list5", "dev/someEvent/2016/12/31/23/_SUCCESS", "zzz")
-    val req2 = new ListObjectsRequest()
-    req2.setBucketName("list5")
-    req2.setDelimiter("/")
-    req2.setPrefix("dev/")
-    val list2  = s3.listObjects(req2)
-    val summaries2 = list2.getObjectSummaries.map(_.getKey).toList
-    list2.getCommonPrefixes.asScala.toList shouldBe List("dev/someEvent/")
-    summaries2 shouldBe Nil
-  }
+    it should "obey delimiters && prefixes v3" in {
+      s3.createBucket("list5")
+      s3.putObject("list5", "dev/someEvent/2017/03/13/00/_SUCCESS", "xxx")
+      s3.putObject("list5", "dev/someEvent/2017/03/13/01/_SUCCESS", "yyy")
+      s3.putObject("list5", "dev/someEvent/2016/12/31/23/_SUCCESS", "zzz")
+      val req2 = new ListObjectsRequest()
+      req2.setBucketName("list5")
+      req2.setDelimiter("/")
+      req2.setPrefix("dev/")
+      val list2 = s3.listObjects(req2)
+      val summaries2 = list2.getObjectSummaries.map(_.getKey).toList
+      list2.getCommonPrefixes.asScala.toList shouldBe List("dev/someEvent/")
+      summaries2 shouldBe Nil
+    }
 
-  it should "list objects in lexicographical order" in {
-    s3.createBucket("list6")
-    s3.putObject("list6", "b", "xx")
-    s3.putObject("list6", "a", "xx")
-    s3.putObject("list6", "0", "xx")
-    val list = s3.listObjects("list6")
-    list.getObjectSummaries.asScala.map(_.getKey).toList shouldBe List("0", "a", "b")
+    it should "list objects in lexicographical order" in {
+      s3.createBucket("list6")
+      s3.putObject("list6", "b", "xx")
+      s3.putObject("list6", "a", "xx")
+      s3.putObject("list6", "0", "xx")
+      val list = s3.listObjects("list6")
+      list.getObjectSummaries.asScala.map(_.getKey).toList shouldBe List("0", "a", "b")
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/ListBucketsTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketsTest.scala
@@ -1,19 +1,12 @@
 package io.findify.s3mock
-
-import java.util.UUID
-
-import better.files.File
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
-import io.findify.s3mock.provider.FileProvider
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
-
-import scala.collection.JavaConversions._
 /**
   * Created by shutty on 8/9/16.
   */
 class ListBucketsTest extends S3MockTest {
-  "s3 mock" should "list empty buckets" in {
-    s3.listBuckets().isEmpty shouldBe true
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    it should "list empty buckets" in {
+      s3.listBuckets().isEmpty shouldBe true
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/MapMetadataStoreTest.scala
+++ b/src/test/scala/io/findify/s3mock/MapMetadataStoreTest.scala
@@ -3,23 +3,27 @@ package io.findify.s3mock
 import java.util
 
 import com.amazonaws.services.s3.model.ObjectMetadata
-import io.findify.s3mock.provider.metadata.MapMetadataStore
+import io.findify.s3mock.provider.metadata.{InMemoryMetadataStore, MapMetadataStore, MetadataStore}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
-
-import scala.collection.JavaConverters._
 /**
   * Created by shutty on 3/13/17.
   */
 class MapMetadataStoreTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-  val mm = new MapMetadataStore("/tmp/s3")
 
-  "map metadata store" should "save md to a fresh store" in {
-    val meta = new ObjectMetadata()
-    val user = new util.HashMap[String,String]()
-    user.put("foo", "bar")
-    meta.setUserMetadata(user)
-    mm.put("foo", "bar", meta)
-    val m2 = mm.get("foo", "bar").get
-    m2.getUserMetadata shouldBe meta.getUserMetadata
+  for (metadataStore <- List((new MapMetadataStore("/tmp/s3"), "MapMetadataStore"),
+    (new InMemoryMetadataStore, "InMemoryMetadataStore"))) {
+    metadataStore._2 should behave like mdStoreBehaviour(metadataStore._1)
+  }
+
+  def mdStoreBehaviour(mm: => MetadataStore) = {
+    it should "save md to a fresh store" in {
+      val meta = new ObjectMetadata()
+      val user = new util.HashMap[String, String]()
+      user.put("foo", "bar")
+      meta.setUserMetadata(user)
+      mm.put("foo", "bar", meta)
+      val m2 = mm.get("foo", "bar").get
+      m2.getUserMetadata shouldBe meta.getUserMetadata
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/MultipartUploadTest.scala
+++ b/src/test/scala/io/findify/s3mock/MultipartUploadTest.scala
@@ -21,66 +21,68 @@ import scala.util.Random
   * Created by shutty on 8/10/16.
   */
 class MultipartUploadTest extends S3MockTest {
-  implicit val system = ActorSystem.create("test")
-  implicit val mat = ActorMaterializer()
-  val http = Http(system)
+  override def behaviour(fixture: => Fixture) = {
+    implicit val system = ActorSystem.create("test")
+    implicit val mat = ActorMaterializer()
+    val http = Http(system)
+    val s3 = fixture.client
+    val port = fixture.port
 
-  "s3" should "upload multipart files" in {
-    s3.createBucket("getput")
-    val response1 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = "http://127.0.0.1:8001/getput/foo2?uploads")), 10.minutes)
-    val data = Await.result(response1.entity.dataBytes.fold(ByteString(""))(_ ++ _).runWith(Sink.head), 10.seconds)
-    val uploadId = (scala.xml.XML.loadString(data.utf8String) \ "UploadId").text
-    val response2 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:8001/getput/foo2?partNumber=1&uploadId=$uploadId", entity = "foo")), 10.minutes)
-    response2.status.intValue() shouldBe 200
-    val response3 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:8001/getput/foo2?partNumber=2&uploadId=$uploadId", entity = "boo")), 10.minutes)
-    response3.status.intValue() shouldBe 200
-    val commit = """<CompleteMultipartUpload>
-                   |  <Part>
-                   |    <PartNumber>1</PartNumber>
-                   |    <ETag>ETag</ETag>
-                   |  </Part>
-                   |  <Part>
-                   |    <PartNumber>2</PartNumber>
-                   |    <ETag>ETag</ETag>
-                   |  </Part>
-                   |</CompleteMultipartUpload>""".stripMargin
-    val response4 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:8001/getput/foo2?uploadId=$uploadId", entity = commit)), 10.minutes)
-    response4.status.intValue() shouldBe 200
+    it should "upload multipart files" in {
+      s3.createBucket("getput")
+      val response1 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:$port/getput/foo2?uploads")), 10.minutes)
+      val data = Await.result(response1.entity.dataBytes.fold(ByteString(""))(_ ++ _).runWith(Sink.head), 10.seconds)
+      val uploadId = (scala.xml.XML.loadString(data.utf8String) \ "UploadId").text
+      val response2 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:$port/getput/foo2?partNumber=1&uploadId=$uploadId", entity = "foo")), 10.minutes)
+      response2.status.intValue() shouldBe 200
+      val response3 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:$port/getput/foo2?partNumber=2&uploadId=$uploadId", entity = "boo")), 10.minutes)
+      response3.status.intValue() shouldBe 200
+      val commit = """<CompleteMultipartUpload>
+          |  <Part>
+          |    <PartNumber>1</PartNumber>
+          |    <ETag>ETag</ETag>
+          |  </Part>
+          |  <Part>
+          |    <PartNumber>2</PartNumber>
+          |    <ETag>ETag</ETag>
+          |  </Part>
+          |</CompleteMultipartUpload>""".stripMargin
+      val response4 = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = s"http://127.0.0.1:$port/getput/foo2?uploadId=$uploadId", entity = commit)), 10.minutes)
+      response4.status.intValue() shouldBe 200
 
-    getContent(s3.getObject("getput", "foo2")) shouldBe "fooboo"
-  }
-
-  it should "work with java sdk" in {
-    s3.createBucket("getput")
-    val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("getput", "foo4"))
-    val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(10).withKey("foo4").withPartNumber(1).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("hellohello".getBytes())))
-    val p2 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(10).withKey("foo4").withPartNumber(2).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("worldworld".getBytes())))
-    val result = s3.completeMultipartUpload(new CompleteMultipartUploadRequest("getput", "foo4", init.getUploadId, List(p1.getPartETag, p2.getPartETag).asJava))
-    result.getKey shouldBe "foo4"
-    getContent(s3.getObject("getput", "foo4")) shouldBe "hellohelloworldworld"
-  }
-  it should "work with large blobs" in {
-    val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("getput", "fooLarge"))
-    val blobs = for ( i <- 0 to 200) yield {
-      val blob1 = new Array[Byte](10000)
-      Random.nextBytes(blob1)
-      val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(blob1.length).withKey("fooLarge").withPartNumber(i).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream(blob1)))
-      blob1 -> p1.getPartETag
+      getContent(s3.getObject("getput", "foo2")) shouldBe "fooboo"
     }
-    val result = s3.completeMultipartUpload(new CompleteMultipartUploadRequest("getput", "fooLarge", init.getUploadId, blobs.map(_._2).asJava))
-    result.getKey shouldBe "fooLarge"
-    DigestUtils.md5Hex(s3.getObject("getput", "fooLarge").getObjectContent) shouldBe DigestUtils.md5Hex(blobs.map(_._1).fold(Array[Byte]())(_ ++ _))
 
-    
-  }
-
-
-  it should "produce NoSuchBucket if bucket does not exist" in {
-    val exc = intercept[AmazonS3Exception] {
-      val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("aws-404", "foo4"))
-      val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("aws-404").withPartSize(10).withKey("foo4").withPartNumber(1).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("hellohello".getBytes())))
+    it should "work with java sdk" in {
+      s3.createBucket("getput")
+      val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("getput", "foo4"))
+      val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(10).withKey("foo4").withPartNumber(1).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("hellohello".getBytes())))
+      val p2 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(10).withKey("foo4").withPartNumber(2).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("worldworld".getBytes())))
+      val result = s3.completeMultipartUpload(new CompleteMultipartUploadRequest("getput", "foo4", init.getUploadId, List(p1.getPartETag, p2.getPartETag).asJava))
+      result.getKey shouldBe "foo4"
+      getContent(s3.getObject("getput", "foo4")) shouldBe "hellohelloworldworld"
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchBucket"
+    it should "work with large blobs" in {
+      val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("getput", "fooLarge"))
+      val blobs = for (i <- 0 to 200) yield {
+        val blob1 = new Array[Byte](10000)
+        Random.nextBytes(blob1)
+        val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("getput").withPartSize(blob1.length).withKey("fooLarge").withPartNumber(i).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream(blob1)))
+        blob1 -> p1.getPartETag
+      }
+      val result = s3.completeMultipartUpload(new CompleteMultipartUploadRequest("getput", "fooLarge", init.getUploadId, blobs.map(_._2).asJava))
+      result.getKey shouldBe "fooLarge"
+      DigestUtils.md5Hex(s3.getObject("getput", "fooLarge").getObjectContent) shouldBe DigestUtils.md5Hex(blobs.map(_._1).fold(Array[Byte]())(_ ++ _))
+    }
+
+
+    it should "produce NoSuchBucket if bucket does not exist" in {
+      val exc = intercept[AmazonS3Exception] {
+        val init = s3.initiateMultipartUpload(new InitiateMultipartUploadRequest("aws-404", "foo4"))
+        val p1 = s3.uploadPart(new UploadPartRequest().withBucketName("aws-404").withPartSize(10).withKey("foo4").withPartNumber(1).withUploadId(init.getUploadId).withInputStream(new ByteArrayInputStream("hellohello".getBytes())))
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchBucket"
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/PutBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/PutBucketTest.scala
@@ -4,13 +4,16 @@ import scala.collection.JavaConversions._
   * Created by shutty on 8/10/16.
   */
 class PutBucketTest extends S3MockTest {
-  "s3 mock" should "create buckets" in {
-    s3.listBuckets().isEmpty shouldBe true
-    s3.createBucket("hello").getName shouldBe "hello"
-    s3.listBuckets().exists(_.getName == "hello") shouldBe true
-  }
-  it should "create buckets with region" in {
-    s3.createBucket("hello2", "us-west-1")
-    s3.listBuckets().exists(_.getName == "hello2") shouldBe true
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    it should "create buckets" in {
+      s3.listBuckets().isEmpty shouldBe true
+      s3.createBucket("hello").getName shouldBe "hello"
+      s3.listBuckets().exists(_.getName == "hello") shouldBe true
+    }
+    it should "create buckets with region" in {
+      s3.createBucket("hello2", "us-west-1")
+      s3.listBuckets().exists(_.getName == "hello2") shouldBe true
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/S3MockTest.scala
+++ b/src/test/scala/io/findify/s3mock/S3MockTest.scala
@@ -6,7 +6,8 @@ import better.files.File
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.S3Object
-import io.findify.s3mock.provider.FileProvider
+import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
+import io.findify.s3mock.provider.{FileProvider, InMemoryProvider}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.io.Source
@@ -15,23 +16,43 @@ import scala.io.Source
   * Created by shutty on 8/9/16.
   */
 trait S3MockTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-  val s3 = new AmazonS3Client(new BasicAWSCredentials("hello", "world"))
-  s3.setEndpoint("http://127.0.0.1:8001")
+  private val workDir = s"/tmp/${UUID.randomUUID()}"
+  private val fileBasedS3 = new AmazonS3Client(new BasicAWSCredentials("hello", "world"))
+  private val fileBasedPort = 8001
+  private val fileBasedServer = new S3Mock(fileBasedPort, new FileProvider(workDir))
+  private val fileBasedTransferManager: TransferManager = TransferManagerBuilder.standard().withS3Client(fileBasedS3).build()
+  fileBasedS3.setEndpoint(s"http://127.0.0.1:$fileBasedPort")
 
-  val workDir = s"/tmp/${UUID.randomUUID()}"
-  val server = new S3Mock(8001, new FileProvider(workDir))
+  private val inMemoryS3 = new AmazonS3Client(new BasicAWSCredentials("hello", "world"))
+  private val inMemoryPort = 8002
+  private val inMemoryServer = new S3Mock(inMemoryPort, new InMemoryProvider)
+  private val inMemoryTransferManager: TransferManager = TransferManagerBuilder.standard().withS3Client(inMemoryS3).build()
+  inMemoryS3.setEndpoint(s"http://127.0.0.1:$inMemoryPort")
+
+  case class Fixture(server: S3Mock, client: AmazonS3Client, tm: TransferManager, name: String, port: Int)
+  val fixtures = List(Fixture(fileBasedServer, fileBasedS3, fileBasedTransferManager, "file based S3Mock", fileBasedPort),
+    Fixture(inMemoryServer, inMemoryS3, inMemoryTransferManager, "in-memory S3Mock", inMemoryPort))
+
+  def behaviour(fixture: => Fixture) : Unit
+
+  for (fixture <- fixtures) {
+    fixture.name should behave like behaviour(fixture)
+  }
 
   override def beforeAll = {
     if (!File(workDir).exists) File(workDir).createDirectory()
-    server.start
+    fileBasedServer.start
+    inMemoryServer.start
     super.beforeAll
   }
   override def afterAll = {
     super.afterAll
-    server.stop
+    inMemoryServer.stop
+    fileBasedServer.stop
+    inMemoryTransferManager.shutdownNow()
     File(workDir).delete()
   }
-
   def getContent(s3Object: S3Object): String = Source.fromInputStream(s3Object.getObjectContent, "UTF-8").mkString
 
 }
+

--- a/src/test/scala/io/findify/s3mock/awscli/GetObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/awscli/GetObjectTest.scala
@@ -12,42 +12,46 @@ import scala.concurrent.duration._
   * Created by shutty on 8/28/16.
   */
 class GetObjectTest extends AWSCliTest {
-  "awscli cp" should "receive LastModified header" in {
-    s3.createBucket("awscli-lm")
-    s3.putObject("awscli-lm", "foo", "bar")
-    val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.GET, uri = "http://127.0.0.1:8001/awscli-lm/foo")), 10.seconds)
-    response.headers.find(_.is("last-modified")).map(_.value()) shouldBe Some("Thu, 01 Jan 1970 00:00:00 GMT")
-    response.entity.contentLengthOption shouldBe Some(3)
-  }
-  it should "deal with HEAD requests" in {
-    s3.createBucket("awscli-head")
-    s3.putObject("awscli-head", "foo2", "bar")
-    val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.HEAD, uri = "http://127.0.0.1:8001/awscli-head/foo2")), 10.seconds)
-    response.headers.find(_.is("last-modified")).map(_.value()) shouldBe Some("Thu, 01 Jan 1970 00:00:00 GMT")
-    response.entity.contentLengthOption shouldBe Some(0)
-    Await.result(response.entity.dataBytes.fold(ByteString(""))(_ ++ _).runWith(Sink.head), 10.seconds).utf8String shouldBe ""
-  }
-  it should "deal with metadata requests" in {
-    s3.createBucket("awscli-head2")
-    s3.putObject("awscli-head2", "foo", "bar")
-    val meta = s3.getObjectMetadata("awscli-head2", "foo")
-    meta.getContentLength shouldBe 3
-  }
-  it should "respond with status 404 if key does not exist" in {
-    s3.createBucket("awscli")
-    val exc = intercept[AmazonS3Exception] {
-      s3.getObject("awscli", "doesnotexist")
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    val port = fixture.port
+    it should "receive LastModified header with AWS CLI" in {
+      s3.createBucket("awscli-lm")
+      s3.putObject("awscli-lm", "foo", "bar")
+      val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.GET, uri = s"http://127.0.0.1:$port/awscli-lm/foo")), 10.seconds)
+      response.headers.find(_.is("last-modified")).map(_.value()) shouldBe Some("Thu, 01 Jan 1970 00:00:00 GMT")
+      response.entity.contentLengthOption shouldBe Some(3)
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchKey"
-  }
-
-  it should "respond with status 404 if bucket does not exist" in {
-
-    val exc = intercept[AmazonS3Exception] {
-      s3.getObject("awscli-404", "doesnotexist")
+    it should "deal with HEAD requests with AWS CLI" in {
+      s3.createBucket("awscli-head")
+      s3.putObject("awscli-head", "foo2", "bar")
+      val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.HEAD, uri = s"http://127.0.0.1:$port/awscli-head/foo2")), 10.seconds)
+      response.headers.find(_.is("last-modified")).map(_.value()) shouldBe Some("Thu, 01 Jan 1970 00:00:00 GMT")
+      response.entity.contentLengthOption shouldBe Some(0)
+      Await.result(response.entity.dataBytes.fold(ByteString(""))(_ ++ _).runWith(Sink.head), 10.seconds).utf8String shouldBe ""
     }
-    exc.getStatusCode shouldBe 404
-    exc.getErrorCode shouldBe "NoSuchBucket"
+    it should "deal with metadata requests with AWS CLI" in {
+      s3.createBucket("awscli-head2")
+      s3.putObject("awscli-head2", "foo", "bar")
+      val meta = s3.getObjectMetadata("awscli-head2", "foo")
+      meta.getContentLength shouldBe 3
+    }
+    it should "respond with status 404 if key does not exist with AWS CLI" in {
+      s3.createBucket("awscli")
+      val exc = intercept[AmazonS3Exception] {
+        s3.getObject("awscli", "doesnotexist")
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchKey"
+    }
+
+    it should "respond with status 404 if bucket does not exist with AWS CLI" in {
+
+      val exc = intercept[AmazonS3Exception] {
+        s3.getObject("awscli-404", "doesnotexist")
+      }
+      exc.getStatusCode shouldBe 404
+      exc.getErrorCode shouldBe "NoSuchBucket"
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/awscli/PutBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/awscli/PutBucketTest.scala
@@ -9,8 +9,12 @@ import scala.collection.JavaConversions._
   * Created by shutty on 8/28/16.
   */
 class PutBucketTest extends AWSCliTest {
-  "awscli mb" should "create bucket" in {
-    val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.PUT, uri = "http://127.0.0.1:8001/awscli")), 10.seconds)
-    s3.listBuckets().exists(_.getName == "awscli") shouldBe true
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    val port = fixture.port
+    it should "create bucket with AWS CLI" in {
+      val response = Await.result(http.singleRequest(HttpRequest(method = HttpMethods.PUT, uri = s"http://127.0.0.1:$port/awscli")), 10.seconds)
+      s3.listBuckets().exists(_.getName == "awscli") shouldBe true
+    }
   }
 }

--- a/src/test/scala/io/findify/s3mock/transfermanager/PutGetTest.scala
+++ b/src/test/scala/io/findify/s3mock/transfermanager/PutGetTest.scala
@@ -3,7 +3,6 @@ package io.findify.s3mock.transfermanager
 import java.io.{ByteArrayInputStream, File, FileInputStream}
 
 import com.amazonaws.services.s3.model.ObjectMetadata
-import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 import io.findify.s3mock.S3MockTest
 
 import scala.io.Source
@@ -12,33 +11,31 @@ import scala.io.Source
   * Created by shutty on 11/23/16.
   */
 class PutGetTest extends S3MockTest {
-  val tm = TransferManagerBuilder.standard().withS3Client(s3).build()
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    val tm = fixture.tm
 
-  override def afterAll = {
-    tm.shutdownNow()
-    super.afterAll
-  }
+    it should "put files with TransferManager" in {
+      s3.createBucket("tm1")
+      val upload = tm.upload("tm1", "hello1", new ByteArrayInputStream("hello".getBytes), new ObjectMetadata())
+      val result = upload.waitForUploadResult()
+      result.getKey shouldBe "hello1"
+    }
 
-  "transfer manager" should "put files" in {
-    s3.createBucket("tm1")
-    val upload = tm.upload("tm1", "hello1", new ByteArrayInputStream("hello".getBytes), new ObjectMetadata())
-    val result = upload.waitForUploadResult()
-    result.getKey shouldBe "hello1"
-  }
+    it should "download files with TransferManager" in {
+      val file = File.createTempFile("hello1", ".s3mock")
+      val download = tm.download("tm1", "hello1", file)
+      download.waitForCompletion()
+      val result = Source.fromInputStream(new FileInputStream(file), "UTF-8").mkString
+      result shouldBe "hello"
+    }
 
-  it should "download files" in {
-    val file = File.createTempFile("hello1", ".s3mock")
-    val download = tm.download("tm1", "hello1", file)
-    download.waitForCompletion()
-    val result = Source.fromInputStream(new FileInputStream(file), "UTF-8").mkString
-    result shouldBe "hello"
-  }
-
-  it should "copy file" in {
-    val copy = tm.copy("tm1", "hello1", "tm1", "hello2")
-    val result = copy.waitForCopyResult()
-    result.getDestinationKey shouldBe "hello2"
-    val hello2 = s3.getObject("tm1", "hello2")
-    getContent(hello2) shouldBe "hello"
+    it should "copy file with TransferManager" in {
+      val copy = tm.copy("tm1", "hello1", "tm1", "hello2")
+      val result = copy.waitForCopyResult()
+      result.getDestinationKey shouldBe "hello2"
+      val hello2 = s3.getObject("tm1", "hello2")
+      getContent(hello2) shouldBe "hello"
+    }
   }
 }


### PR DESCRIPTION
This is an attempt to implement the in-memory backend mentioned in https://github.com/findify/s3mock/issues/25 . I believe it to be complete (on the same level as `FileProvider`, but am happy to work on/rework any part of it, or abandon it altogether should another solution be preferable.

In terms of the behaviour, it should be mostly identical with the existing `FileProvider`, apart from:
- will calculate md5sums for `ListBucket` requests. `FileProvider` seems to return `0` for all.
- will throw `NoSuchBucketException` when a delete request is received against a nonexistent bucket. `FileProvider` throws `NoSuchKeyException` only. The correct semantics are unclear to me.
- does not care about about separators and doesn't need to strip leading slashes, as it's not bound to the file system for storage. This should solve https://github.com/findify/s3mock/issues/28 (Windows compatibility) in the case when in-memory storage is acceptable.

The most invasive changes have been to the test suite, as I was trying to find a way to automatically run the tests for both providers. I have tried to keep the changes clean (the github diff viewer marks huge blocks as changed, but it's mostly indentation due to wrapping the tests in an encapsulating method), but I'm not an expert in scalatest at all, so there may be a preferable way to do this.

Thanks for creating s3mock!

