### PR TITLE
Ranged get requests support

### DIFF
--- a/src/main/scala/io/findify/s3mock/Main.scala
+++ b/src/main/scala/io/findify/s3mock/Main.scala
@@ -1,5 +1,6 @@
 package io.findify.s3mock
 
+import better.files.File
 import io.findify.s3mock.provider.FileProvider
 
 /**
@@ -7,7 +8,7 @@ import io.findify.s3mock.provider.FileProvider
   */
 object Main {
   def main(args: Array[String]): Unit = {
-    val server = new S3Mock(8001, new FileProvider("/tmp/s3mock"))
+    val server = new S3Mock(8001, new FileProvider(File.newTemporaryDirectory(prefix = "s3mock").pathAsString))
     server.start
   }
 }

--- a/src/main/scala/io/findify/s3mock/S3ChunkedProtocolStage.scala
+++ b/src/main/scala/io/findify/s3mock/S3ChunkedProtocolStage.scala
@@ -1,12 +1,9 @@
 package io.findify.s3mock
 
 import akka.stream._
-import akka.stream.scaladsl.{Flow, GraphDSL}
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
 import com.typesafe.scalalogging.LazyLogging
-
-import scala.util.matching.Regex
 
 /**
   * Created by shutty on 8/11/16.
@@ -20,7 +17,6 @@ class ChunkBuffer extends LazyLogging {
   def addChunk(data:ByteString) = buffer = buffer ++ data
   def readHeader:Option[Header] = {
     val headerBuffer = buffer.take(90)
-    val bufferString = headerBuffer.utf8String
     val size = headerBuffer.takeWhile(hexChars.contains)
     val sig = headerBuffer.drop(size.length).take(83)
     if ((size.length <= 8) && (sig.length == 83) && sig.startsWith(";chunk-signature=") && sig.endsWith("\r\n")) {

--- a/src/main/scala/io/findify/s3mock/S3Mock.scala
+++ b/src/main/scala/io/findify/s3mock/S3Mock.scala
@@ -1,29 +1,20 @@
 package io.findify.s3mock
 
 import akka.actor.ActorSystem
-import akka.event.Logging
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
-import akka.http.scaladsl._
-import akka.http.scaladsl.model.headers.Location
-import akka.http.scaladsl.model.{HttpHeader, HttpResponse, Multipart, StatusCodes}
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
-import akka.stream.scaladsl.{Framing, Sink}
-import akka.util.ByteString
+import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.LazyLogging
-import io.findify.s3mock.error.NoSuchKeyException
 import io.findify.s3mock.provider.{FileProvider, Provider}
-import io.findify.s3mock.request.{CompleteMultipartUpload, CreateBucketConfiguration}
 import io.findify.s3mock.route.{PutObject, _}
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.io.Source
-import scala.util.{Failure, Success, Try}
 /**
   * Created by shutty on 8/9/16.
   */
-class S3Mock(port:Int, provider:Provider)(implicit system:ActorSystem = ActorSystem.create("sqsmock")) extends LazyLogging {
+class S3Mock(port:Int, provider:Provider)(implicit system:ActorSystem = ActorSystem.create("s3mock")) extends LazyLogging {
   implicit val p = provider
   private var bind:Http.ServerBinding = _
 

--- a/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
@@ -1,5 +1,4 @@
 package io.findify.s3mock.provider
-import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.util.UUID
 
 import akka.http.scaladsl.model.DateTime

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,1 +1,0 @@
-../../main/resources/application.conf

--- a/src/test/scala/io/findify/s3mock/JavaExampleTest.scala
+++ b/src/test/scala/io/findify/s3mock/JavaExampleTest.scala
@@ -1,14 +1,12 @@
 package io.findify.s3mock
 
-import java.util.UUID
-
-import scala.collection.JavaConversions._
 import better.files.File
 import com.amazonaws.auth.{AnonymousAWSCredentials, BasicAWSCredentials}
 import com.amazonaws.services.s3.AmazonS3Client
 import io.findify.s3mock.provider.FileProvider
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
+import scala.collection.JavaConversions._
 import scala.io.Source
 
 /**
@@ -18,7 +16,7 @@ class JavaExampleTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   val s3 = new AmazonS3Client(new AnonymousAWSCredentials())
   s3.setEndpoint("http://127.0.0.1:8001")
 
-  val workDir = s"/tmp/${UUID.randomUUID()}"
+  val workDir = File.newTemporaryDirectory().pathAsString
   val server = new S3Mock(8001, new FileProvider(workDir))
 
   override def beforeAll = {

--- a/src/test/scala/io/findify/s3mock/ListBucketEmptyWorkdirTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketEmptyWorkdirTest.scala
@@ -1,12 +1,12 @@
 package io.findify.s3mock
 
-import java.util.UUID
-
-import scala.collection.JavaConverters._
+import better.files.File
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
 import io.findify.s3mock.provider.FileProvider
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
 
 /**
   * Created by shutty on 8/30/16.
@@ -14,7 +14,7 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 class ListBucketEmptyWorkdirTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   lazy val s3 = new AmazonS3Client(new BasicAWSCredentials("hello", "world"))
 
-  val workDir = s"/tmp/${UUID.randomUUID()}"
+  val workDir = File.newTemporaryDirectory().pathAsString
   lazy val server = new S3Mock(8001, new FileProvider(workDir))
 
   override def beforeAll = {

--- a/src/test/scala/io/findify/s3mock/MapMetadataStoreTest.scala
+++ b/src/test/scala/io/findify/s3mock/MapMetadataStoreTest.scala
@@ -2,16 +2,16 @@ package io.findify.s3mock
 
 import java.util
 
+import better.files.File
 import com.amazonaws.services.s3.model.ObjectMetadata
 import io.findify.s3mock.provider.metadata.MapMetadataStore
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-import scala.collection.JavaConverters._
 /**
   * Created by shutty on 3/13/17.
   */
 class MapMetadataStoreTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-  val mm = new MapMetadataStore("/tmp/s3")
+  val mm = new MapMetadataStore(File.newTemporaryDirectory(prefix = "s3").pathAsString)
 
   "map metadata store" should "save md to a fresh store" in {
     val meta = new ObjectMetadata()

--- a/src/test/scala/io/findify/s3mock/S3MockTest.scala
+++ b/src/test/scala/io/findify/s3mock/S3MockTest.scala
@@ -1,7 +1,5 @@
 package io.findify.s3mock
 
-import java.util.UUID
-
 import better.files.File
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
@@ -18,7 +16,7 @@ trait S3MockTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   val s3 = new AmazonS3Client(new BasicAWSCredentials("hello", "world"))
   s3.setEndpoint("http://127.0.0.1:8001")
 
-  val workDir = s"/tmp/${UUID.randomUUID()}"
+  val workDir = File.newTemporaryDirectory().pathAsString
   val server = new S3Mock(8001, new FileProvider(workDir))
 
   override def beforeAll = {


### PR DESCRIPTION
Added ability to retrieve part of S3 object by supplying byte range in `Range` header of `GET` request.
Performed minor cleanup changes.