### PR TITLE
Support Alpakka multipart uploads

### DIFF
--- a/src/main/scala/io/findify/s3mock/route/PutObjectMultipart.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObjectMultipart.scala
@@ -1,79 +1,72 @@
 package io.findify.s3mock.route
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
+import akka.NotUsed
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.ETag
 import akka.http.scaladsl.server.Directives._
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.{FlowShape, Graph, Materializer}
 import akka.util.ByteString
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.S3ChunkedProtocolStage
 import io.findify.s3mock.error.{InternalErrorException, NoSuchBucketException}
 import io.findify.s3mock.provider.Provider
+import org.apache.commons.codec.digest.DigestUtils
 
-import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 /**
   * Created by shutty on 8/19/16.
   */
-case class PutObjectMultipart(implicit provider:Provider, mat:Materializer) extends LazyLogging {
-  def route(bucket:String, path:String) = parameter('partNumber, 'uploadId) { (partNumber:String, uploadId:String) =>
+case class PutObjectMultipart(implicit provider: Provider, mat: Materializer) extends LazyLogging {
+
+  type EntityDecoder = Graph[FlowShape[ByteString, ByteString], NotUsed]
+
+  private val defaultEntityEncoder = Flow[ByteString].map(identity)
+
+  def route(bucket: String, path: String) = parameter('partNumber, 'uploadId) { (partNumber: String, uploadId: String) =>
     put {
       logger.debug(s"put multipart object bucket=$bucket path=$path")
-      headerValueByName("authorization") { auth =>
-        completeSigned(bucket, path, partNumber.toInt, uploadId)
-      } ~ completePlain(bucket, path, partNumber.toInt, uploadId)
+      headerValueByName("x-amz-decoded-content-length") { decodedLength =>
+        completeRequest(bucket, path, partNumber.toInt, uploadId, new S3ChunkedProtocolStage)
+      } ~ completeRequest(bucket, path, partNumber.toInt, uploadId)
     } ~ post {
       logger.debug(s"post multipart object bucket=$bucket path=$path")
-      completePlain(bucket, path, partNumber.toInt, uploadId)
+      completeRequest(bucket, path, partNumber.toInt, uploadId)
     }
   }
 
-  def completePlain(bucket:String, path:String, partNumber:Int, uploadId:String) = extractRequest { request =>
-    complete {
-      val result = request.entity.dataBytes
-        .fold(ByteString(""))(_ ++ _)
-        .map(data => {
-          Try(provider.putObjectMultipartPart(bucket, path, partNumber.toInt, uploadId, data.toArray)) match {
-            case Success(()) => HttpResponse(StatusCodes.OK)
-            case Failure(e: NoSuchBucketException) =>
-              HttpResponse(
-                StatusCodes.NotFound,
-                entity = e.toXML.toString()
-              )
-            case Failure(t) =>
-              HttpResponse(
-                StatusCodes.InternalServerError,
-                entity = InternalErrorException(t).toXML.toString()
-              )
-          }
-        }).runWith(Sink.head[HttpResponse])
-      result
+  def completeRequest(bucket: String,
+                      path: String,
+                      partNumber: Int,
+                      uploadId: String,
+                      entityDecoder: EntityDecoder = defaultEntityEncoder) =
+    extractRequest { request =>
+      complete {
+        val result = request.entity.dataBytes
+          .via(entityDecoder)
+          .fold(ByteString(""))(_ ++ _)
+          .map(data => {
+            Try(provider.putObjectMultipartPart(bucket, path, partNumber.toInt, uploadId, data.toArray)) match {
+              case Success(()) =>
+                HttpResponse(
+                  StatusCodes.OK,
+                  entity = HttpEntity( ContentType(MediaTypes.`application/xml`, HttpCharsets.`UTF-8`), "")
+                ).withHeaders(ETag(DigestUtils.md5Hex(data.toArray)))
+              case Failure(e: NoSuchBucketException) =>
+                HttpResponse(
+                  StatusCodes.NotFound,
+                  entity = e.toXML.toString()
+                )
+              case Failure(t) =>
+                HttpResponse(
+                  StatusCodes.InternalServerError,
+                  entity = InternalErrorException(t).toXML.toString()
+                )
+            }
+          }).runWith(Sink.head[HttpResponse])
+        result
+      }
     }
-  }
-
-  def completeSigned(bucket:String, path:String, partNumber:Int, uploadId:String) = extractRequest { request =>
-    complete {
-      val result = request.entity.dataBytes
-        .via(new S3ChunkedProtocolStage)
-        .fold(ByteString(""))(_ ++ _)
-        .map(data => {
-          Try( provider.putObjectMultipartPart(bucket, path, partNumber.toInt, uploadId, data.toArray)) match {
-            case Success(()) => HttpResponse(StatusCodes.OK)
-            case Failure(e: NoSuchBucketException) =>
-              HttpResponse(
-                StatusCodes.NotFound,
-                entity = e.toXML.toString()
-              )
-            case Failure(t) =>
-              HttpResponse(
-                StatusCodes.InternalServerError,
-                entity = InternalErrorException(t).toXML.toString()
-              )
-          }
-        }).runWith(Sink.head[HttpResponse])
-      result
-    }
-  }
 
 }

--- a/src/main/scala/io/findify/s3mock/route/PutObjectMultipartComplete.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObjectMultipartComplete.scala
@@ -1,6 +1,6 @@
 package io.findify.s3mock.route
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.error.{InternalErrorException, NoSuchBucketException}
@@ -20,7 +20,14 @@ case class PutObjectMultipartComplete(implicit provider:Provider) extends LazyLo
           logger.info(s"multipart upload completed for $bucket/$path, id = $uploadId")
           val request = CompleteMultipartUpload(scala.xml.XML.loadString(xml).head)
           Try(provider.putObjectMultipartComplete(bucket, path, uploadId, request)) match {
-            case Success(response) => HttpResponse(StatusCodes.OK, entity = response.toXML.toString)
+            case Success(response) =>
+              HttpResponse(
+                StatusCodes.OK,
+                entity = HttpEntity(
+                  ContentType(MediaTypes.`application/xml`, HttpCharsets.`UTF-8`),
+                  response.toXML.toString()
+                )
+              )
             case Failure(e: NoSuchBucketException) =>
               HttpResponse(
                 StatusCodes.NotFound,

--- a/src/main/scala/io/findify/s3mock/route/PutObjectMultipartStart.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObjectMultipartStart.scala
@@ -1,6 +1,8 @@
 package io.findify.s3mock.route
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import java.nio.charset.StandardCharsets
+
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.error.{InternalErrorException, NoSuchBucketException}
@@ -17,7 +19,13 @@ case class PutObjectMultipartStart(implicit provider:Provider) extends LazyLoggi
       complete {
         logger.info(s"multipart upload start to $bucket/$path")
         Try(provider.putObjectMultipartStart(bucket, path)) match {
-          case Success(result) => HttpResponse(StatusCodes.OK, entity =result.toXML.toString())
+          case Success(result) =>
+            HttpResponse(
+              StatusCodes.OK,
+              entity = HttpEntity(
+                ContentTypes.`application/octet-stream`, result.toXML.toString().getBytes(StandardCharsets.UTF_8)
+              )
+            )
           case Failure(e: NoSuchBucketException) =>
             HttpResponse(
               StatusCodes.NotFound,

--- a/src/test/scala/io/findify/s3mock/alpakka/GetObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/alpakka/GetObjectTest.scala
@@ -25,7 +25,7 @@ class GetObjectTest extends S3MockTest {
     implicit val mat = fixture.mat
 
 
-    it should "get objects via alpakka" ignore {
+    it should "get objects via alpakka" in {
       s3.createBucket("alpakka1")
       s3.putObject("alpakka1", "test1", "foobar")
       val result = Await.result(fixture.alpakka.download("alpakka1", "test1").runWith(Sink.seq), 5.second)
@@ -33,7 +33,7 @@ class GetObjectTest extends S3MockTest {
       str shouldBe "foobar"
     }
 
-    it should "get by range" ignore {
+    it should "get by range" in {
       s3.createBucket("alpakka2")
       s3.putObject("alpakka2", "test2", "foobar")
       val result = Await.result(fixture.alpakka.download("alpakka2", "test2", ByteRange(1, 4)).runWith(Sink.seq), 5.second)

--- a/src/test/scala/io/findify/s3mock/alpakka/MultipartUploadTest.scala
+++ b/src/test/scala/io/findify/s3mock/alpakka/MultipartUploadTest.scala
@@ -1,0 +1,35 @@
+package io.findify.s3mock.alpakka
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import io.findify.s3mock.S3MockTest
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+  * Created by shutty on 5/19/17.
+  */
+class MultipartUploadTest extends S3MockTest {
+
+  override def behaviour(fixture: => Fixture) = {
+    val s3 = fixture.client
+    implicit val sys = fixture.system
+    implicit val mat = fixture.mat
+
+
+    it should "upload multipart files" in {
+      s3.createBucket("alpakka1")
+
+      val result = Await.result(Source.single(ByteString("testcontent1"))
+        .runWith(fixture.alpakka.multipartUpload("alpakka1", "test1")), 5.seconds)
+
+      result.bucket shouldBe "alpakka1"
+      result.key shouldBe "test1"
+
+      getContent(s3.getObject("alpakka1", "test1")) shouldBe "testcontent1"
+    }
+
+
+  }
+}


### PR DESCRIPTION
This fixes #61

I added the correct response content-types for start and stop of the the multipart API which are checked hard by Alpakka. The Amazon S3 client does not seem to check these and the docs don't specify them. All tests are running so it seems this works. 

Also ETags in the responses from the Multipart Part Uploads are mandatory by Alpakka. I added these.

Currently S3Mock assumes that on an authenticated request the content is always chunked. This is only true for the Amazon SDK S3 client but not for Alpakka S3. 

The docs state that chunking is optional for clients (http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html).

I added a detection based on the header `x-amz-decoded-content-length` which is only present when the content is (chunk-)encoded. Based on this the dataBytes from the request are either decoded or not and simply stored like in an unauthenticated request.

This is a rather big change and I would welcome a review and feedback if this could be considered for merging. If any changes are needed just tell me :)

Thank you. 