### PR TITLE
Remove pom dependency type

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ On maven, update your `pom.xml` in the following way:
         <groupId>io.findify</groupId>
         <artifactId>s3mock_2.12</artifactId>
         <version>0.2.3</version>
-        <type>pom</type>
         <scope>test</scope>
     </dependency>
 ```


### PR DESCRIPTION
Since we need to be able to access the s3mock classes, we need a jar dependency and not the pom dependency