### PR TITLE
Add optional env variables for customising the server process

### DIFF
--- a/src/main/scala/io/findify/s3mock/Main.scala
+++ b/src/main/scala/io/findify/s3mock/Main.scala
@@ -1,14 +1,41 @@
 package io.findify.s3mock
 
 import better.files.File
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, AnonymousAWSCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import io.findify.s3mock.provider.FileProvider
 
 /**
   * Created by shutty on 8/9/16.
   */
 object Main {
+  val port = sys.env.get("S3MOCK_PORT").map(Integer.parseInt).getOrElse(8001)
+
   def main(args: Array[String]): Unit = {
-    val server = new S3Mock(8001, new FileProvider(File.newTemporaryDirectory(prefix = "s3mock").pathAsString))
+    val server = new S3Mock(port, new FileProvider(
+      sys.env.get("REPOSITORY_PATH") match {
+        case Some(path) => File(path).pathAsString
+        case None => File.newTemporaryDirectory(prefix = "s3mock").pathAsString
+      }))
     server.start
+
+    sys.env.get("BUCKET_NAME").foreach(name => createBucket(name))
+  }
+
+  def createBucket(bucketName: String): Unit = {
+    val client = clientFor("localhost", port)
+    client.createBucket(bucketName)
+    println("Created bucket: " + bucketName)
+    client.shutdown()
+  }
+
+  def clientFor(host: String, port: Int): AmazonS3 = {
+    val endpoint = new EndpointConfiguration(s"http://$host:$port", "eu-west-1")
+    AmazonS3ClientBuilder.standard()
+      .withPathStyleAccessEnabled(true)
+      .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+      .withEndpointConfiguration(endpoint)
+      .build()
   }
 }


### PR DESCRIPTION
This PR adds these environment variables which are read by Main:
 
1. **S3MOCK_PORT**: Changes the default (8001) port on the server
2. **REPOSITORY_PATH**: If set to an address, the server creates the repository on the given path rather than creating a temporary file. This helps to persist the files when the docker container restarts.
3. **BUCKET_NAME**: Enables automatic creation of a bucket with the given name




 Enables automatic creation of a bucket with environment variable