### PR TITLE
Provide access to JAXB when using Java 9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ dockerfile in docker := new Dockerfile {
   from("openjdk:9.0.1-11-jre-slim")
   expose(8001)
   add(assembly.value, "/app/s3mock.jar")
-  entryPoint("java", "-Xmx128m", "-jar", "/app/s3mock.jar")
+  entryPoint("java", "-Xmx128m", "-jar", "--add-modules", "java.xml.bind", "/app/s3mock.jar")
 }
 imageNames in docker := Seq(
   ImageName(s"findify/s3mock:${version.value.replaceAll("\\+", "_")}"),


### PR DESCRIPTION
Java 9 doesn't consider JAXB part of Java EE APIs as explained here (https://stackoverflow.com/a/43574427/38483). 

Without that extra parameter we get this exception when running the docker image:

```
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:582)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:185)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:496)
        ... 70 more
```