### PR TITLE
[83] Patch OverlappingFileLockException in GetObject.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.224",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test",
-  "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.iq80.leveldb" % "leveldb" % "0.9",
   "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "0.14" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "s3mock"
 
-version := "0.2.4"
+version := "0.2.4-8-jdk-slim"
 
 organization := "io.findify"
 
@@ -59,7 +59,7 @@ mainClass in assembly := Some("io.findify.s3mock.Main")
 test in assembly := {}
 
 dockerfile in docker := new Dockerfile {
-  from("openjdk:9.0.1-11-jre-slim")
+  from("openjdk:8-jdk-slim")
   expose(8001)
   add(assembly.value, "/app/s3mock.jar")
   entryPoint("java", "-Xmx128m", "-jar", "/app/s3mock.jar")

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "s3mock"
 
-version := "0.2.4-8-jdk-slim"
+version := "0.2.4.1"
 
 organization := "io.findify"
 
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.224",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "org.iq80.leveldb" % "leveldb" % "0.9",
+  "org.iq80.leveldb" % "leveldb" % "0.10",
   "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "0.14" % "test"
 )
 
@@ -59,7 +59,7 @@ mainClass in assembly := Some("io.findify.s3mock.Main")
 test in assembly := {}
 
 dockerfile in docker := new Dockerfile {
-  from("openjdk:8-jdk-slim")
+  from("openjdk:9.0.1-11-jre-slim")
   expose(8001)
   add(assembly.value, "/app/s3mock.jar")
   entryPoint("java", "-Xmx128m", "-jar", "/app/s3mock.jar")


### PR DESCRIPTION
The error is this when doing GetObject on a pre-existing file of a pre-existing bucket:
```
java.nio.channels.OverlappingFileLockException: null
	at java.base/sun.nio.ch.SharedFileLockTable.checkList(FileLockTable.java:255)
	at java.base/sun.nio.ch.SharedFileLockTable.add(FileLockTable.java:152)
	at java.base/sun.nio.ch.FileChannelImpl.tryLock(FileChannelImpl.java:1121)
	at java.base/java.nio.channels.FileChannel.tryLock(FileChannel.java:1160)
	at org.iq80.leveldb.impl.DbLock.<init>(DbLock.java:47)
	at org.iq80.leveldb.impl.DbImpl.<init>(DbImpl.java:167)
	at org.iq80.leveldb.impl.Iq80DBFactory.open(Iq80DBFactory.java:82)
	at io.findify.s3mock.provider.metadata.MapMetadataStore.load(MapMetadataStore.scala:50)
	at io.findify.s3mock.provider.metadata.MapMetadataStore.get(MapMetadataStore.scala:26)
	at io.findify.s3mock.provider.FileProvider.getObject(FileProvider.scala:89)
	at io.findify.s3mock.route.GetObject.$anonfun$route$4(GetObject.scala:31)
	at scala.util.Try$.apply(Try.scala:209)
	at io.findify.s3mock.route.GetObject.$anonfun$route$3(GetObject.scala:31)
```
This happens when running s3Mock with the current docker image (openjdk:9.0.1-11-jre-slim), not when running Main locally.

Not all platforms implement file locking the same way: this is a quick fix to a locking problem.

One docker image that works is the one edited here, jdk 8. Other images may work as well.

A different (and better fix) would entail changing the code doing locking.