### PR TITLE
Docker: Allow serving a prepared directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ S3Mock is also available as a [docker container](https://hub.docker.com/r/findif
 docker run -p 8001:8001 findify/s3mock:latest
 ```
 
+To mount a directory containing the prepared content, mount the volume and set the `S3MOCK_DATA_DIR` environment variable:
+```bash
+docker run -p 8001:8001 -v /host/path/to/s3mock/:/tmp/s3mock/ -e "S3MOCK_DATA_DIR=/tmp/s3mock" findify/s3mock:latest
+```
+
 ## Usage
 
 Just point your s3 client to a localhost, enable path-style access, and it should work out of the box.

--- a/src/main/scala/io/findify/s3mock/Main.scala
+++ b/src/main/scala/io/findify/s3mock/Main.scala
@@ -8,7 +8,7 @@ import io.findify.s3mock.provider.FileProvider
   */
 object Main {
   def main(args: Array[String]): Unit = {
-    val server = new S3Mock(8001, new FileProvider(File.newTemporaryDirectory(prefix = "s3mock").pathAsString))
+    val server = new S3Mock(8001, new FileProvider(sys.env.getOrElse("S3MOCK_DATA_DIR", File.newTemporaryDirectory(prefix = "s3mock").pathAsString)))
     server.start
   }
 }


### PR DESCRIPTION
This feature enables the users of the Docker image to serve prepared directory contents by mounting a Docker volume and setting an environment variable.