### PR TITLE
modify test to verify typesafe config loading works fine with s3Mock

### DIFF
--- a/src/test/scala/io/findify/s3mock/TypesafeConfigTest.scala
+++ b/src/test/scala/io/findify/s3mock/TypesafeConfigTest.scala
@@ -11,8 +11,10 @@ import com.typesafe.config.ConfigFactory
 class TypesafeConfigTest  extends S3MockTest {
   override def behaviour(fixture: => Fixture) = {
 
-    it should "load typesafe config files" ignore {
-      val conf = ConfigFactory.parseResources("/test.conf")
+    it should "load typesafe config files" in {
+      val config = ConfigFactory.load("test.conf")
+      config.getString("foo.testConfig") shouldBe "test"
+      val conf = ConfigFactory.parseResources("test.conf")
       conf.getString("foo.testConfig") shouldBe "test"
     }
   }


### PR DESCRIPTION
#56 the leading forward slash was the issue apparently. 