### PR TITLE
Fix empty delimiter string not being considered as None

### DIFF
--- a/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
@@ -53,7 +53,7 @@ class FileProvider(dir:String) extends Provider with LazyLogging {
       Content(fromOs(f.toString).drop(bucketFileString.length+1).dropWhile(_ == '/'), DateTime(f.lastModifiedTime.toEpochMilli), md5, f.size, "STANDARD")
     }).toList
     logger.debug(s"listing bucket contents: ${files.map(_.key)}")
-    val commonPrefixes = delimiter match {
+    val commonPrefixes = normalizeDelimiter(delimiter) match {
       case Some(del) => files.flatMap(f => commonPrefix(f.key, prefixNoLeadingSlash, del)).distinct.sorted
       case None => Nil
     }

--- a/src/main/scala/io/findify/s3mock/provider/InMemoryProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/InMemoryProvider.scala
@@ -53,7 +53,7 @@ class InMemoryProvider extends Provider with LazyLogging {
           Content(name, content.lastModificationTime, DigestUtils.md5Hex(content.data), content.data.length, "STANDARD")
         }
         logger.debug(s"listing bucket contents: ${matchResults.map(_.key)}")
-        val commonPrefixes = delimiter match {
+        val commonPrefixes = normalizeDelimiter(delimiter) match {
           case Some(del) => matchResults.flatMap(f => commonPrefix(f.key, prefix2, del)).toList.sorted.distinct
           case None => Nil
         }

--- a/src/main/scala/io/findify/s3mock/provider/Provider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/Provider.scala
@@ -25,6 +25,8 @@ trait Provider {
   def deleteBucket(bucket:String):Unit
   def copyObject(sourceBucket: String, sourceKey: String, destBucket: String, destKey: String, newMeta: Option[ObjectMetadata] = None): CopyObjectResult
   def copyObjectMultipart(sourceBucket: String, sourceKey: String, destBucket: String, destKey: String,  partNumber:Int, uploadId:String, fromByte: Int, toByte:Int,  meta: Option[ObjectMetadata] = None): CopyObjectResult
+
+  def normalizeDelimiter(delimiter:Option[String]):Option[String] = delimiter.flatMap {s => if(s.isEmpty) None else Some(s)}
 }
 
 

--- a/src/test/scala/io/findify/s3mock/ListBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/ListBucketTest.scala
@@ -204,5 +204,18 @@ class ListBucketTest extends S3MockTest {
       val list = s3.listObjects("list10").getObjectSummaries.asScala.toList
       list.find(_.getKey == "foo").map(_.getLastModified.after(DateTime.now().minusMinutes(1).toDate)) shouldBe Some(true)
     }
+
+    it should "work with empty string delimiters as if no delimiter was provided" in {
+      s3.createBucket("list11")
+      s3.putObject("list11", "sample.jpg", "xxx")
+      s3.putObject("list11", "photos/2006/January/sample.jpg", "yyy")
+
+      val req = new ListObjectsRequest()
+      req.setBucketName("list11")
+      req.setDelimiter("")
+      req.setPrefix("")
+      val list = s3.listObjects(req)
+      list.getObjectSummaries.asScala.map(_.getKey).toList should contain only ("sample.jpg", "photos/2006/January/sample.jpg")
+    }
   }
 }


### PR DESCRIPTION
In most of Python libraries like boto3, when listing contents of a bucket, an empty string as delimiter is considered as not provided (see for instance [Apache Airflow](https://github.com/apache/incubator-airflow/blob/master/airflow/hooks/S3_hook.py#L118)). Also when using the `boto3` library this 2 calls are semantically equivalent and return all keys under the bucket:

```
boto3.client('s3', region_name='eu-west-1').list_objects_v2(Bucket="mybucket")
```
and

```
boto3.client('s3', region_name='eu-west-1').list_objects_v2(Bucket="mybucket", Prefix='', Delimiter='')
```

But in S3Mock whenever you provide a string, it becomes `Some("")` as the delimiter and returns nothing. Since it doesn't make much sense to have an empty string as delimiter, I've created this PR to transform that into None in order to be able to interoperate with popular Python frameworks that hardcode the `""` into the call.