### PR TITLE
Do not duplicate Last-Modified header

### DIFF
--- a/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
@@ -82,7 +82,7 @@ class FileProvider(dir:String) extends Provider with LazyLogging {
   override def getObject(bucket:String, key:String): GetObjectData = {
     val bucketFile = File(s"$dir/$bucket")
     val file = File(s"$dir/$bucket/$key")
-    logger.debug(s"reading object for s://$bucket/$key")
+    logger.debug(s"reading object for s3://$bucket/$key")
     if (!bucketFile.exists) throw NoSuchBucketException(bucket)
     if (!file.exists) throw NoSuchKeyException(bucket, key)
     if (file.isDirectory) throw NoSuchKeyException(bucket, key)

--- a/src/main/scala/io/findify/s3mock/route/GetObject.scala
+++ b/src/main/scala/io/findify/s3mock/route/GetObject.scala
@@ -25,51 +25,53 @@ case class GetObject(implicit provider: Provider) extends LazyLogging {
   def route(bucket: String, path: String, params: Map[String, String]) = get {
 
     withRangeSupport {
-      complete {
-        logger.debug(s"get object: bucket=$bucket, path=$path")
+      respondWithDefaultHeader(`Last-Modified`(DateTime(1970, 1, 1))) {
+        complete {
+          logger.debug(s"get object: bucket=$bucket, path=$path")
 
-        Try(provider.getObject(bucket, path)) match {
-          case Success(GetObjectData(data, metaOption)) =>
-            metaOption match {
-              case Some(meta) =>
-                val entity: Strict = ContentType.parse(meta.getContentType) match {
-                  case Right(value) => HttpEntity(value, data)
-                  case Left(error) => HttpEntity(data)
-                }
+          Try(provider.getObject(bucket, path)) match {
+            case Success(GetObjectData(data, metaOption)) =>
+              metaOption match {
+                case Some(meta) =>
+                  val entity: Strict = ContentType.parse(meta.getContentType) match {
+                    case Right(value) => HttpEntity(value, data)
+                    case Left(error) => HttpEntity(data)
+                  }
 
-                if (params.contains("tagging")) {
-                  handleTaggingRequest(meta)
-                } else {
+                  if (params.contains("tagging")) {
+                    handleTaggingRequest(meta)
+                  } else {
+                    HttpResponse(
+                      status = StatusCodes.OK,
+                      entity = entity,
+                      headers = metadataToHeaderList(meta)
+                    )
+                  }
+
+                case None =>
                   HttpResponse(
                     status = StatusCodes.OK,
-                    entity = entity,
-                    headers = `Last-Modified`(DateTime(1970, 1, 1)) :: metadataToHeaderList(meta)
+                    entity = HttpEntity(data),
+                    headers = List()
                   )
-                }
-
-              case None =>
-                HttpResponse(
-                  status = StatusCodes.OK,
-                  entity = HttpEntity(data),
-                  headers = List(`Last-Modified`(DateTime(1970, 1, 1)))
-                )
-            }
-          case Failure(e: NoSuchKeyException) =>
-            HttpResponse(
-              StatusCodes.NotFound,
-              entity = e.toXML.toString()
-            )
-          case Failure(e: NoSuchBucketException) =>
-            HttpResponse(
-              StatusCodes.NotFound,
-              entity = e.toXML.toString()
-            )
-          case Failure(t) =>
-            logger.error("Oops: ", t)
-            HttpResponse(
-              StatusCodes.InternalServerError,
-              entity = InternalErrorException(t).toXML.toString()
-            )
+              }
+            case Failure(e: NoSuchKeyException) =>
+              HttpResponse(
+                StatusCodes.NotFound,
+                entity = e.toXML.toString()
+              )
+            case Failure(e: NoSuchBucketException) =>
+              HttpResponse(
+                StatusCodes.NotFound,
+                entity = e.toXML.toString()
+              )
+            case Failure(t) =>
+              logger.error("Oops: ", t)
+              HttpResponse(
+                StatusCodes.InternalServerError,
+                entity = InternalErrorException(t).toXML.toString()
+              )
+          }
         }
       }
     }


### PR DESCRIPTION
By default when we had metadata, header `Last-Modified` was being returned twice:
```
curl -I -X GET localhost:8001/mybucket/hello.txt
HTTP/1.1 200 OK
Accept-Ranges: bytes
Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT
Last-Modified: Thu, 21 Jun 2018 11:44:44 GMT
Timeout-Access: <function1>
Expect: 100-continue
Content-MD5: d41d8cd98f00b204e9800998ecf8427e
Accept-Encoding: identity
User-Agent: aws-cli/1.15.41 Python/3.6.5 Linux/4.15.0-23-generic botocore/1.10.41
Host: localhost:8001
ETag: d41d8cd98f00b204e9800998ecf8427e
Server: akka-http/10.1.0
Date: Thu, 21 Jun 2018 11:45:13 GMT
Content-Type: text/plain
Content-Length: 0
```

Making some functions from the boto3 library fail with an exception because it is trying to parse as a date the concatenation of those two dates:

```
In [100]: client.head_object(Key="hello.txt", Bucket="mybucket")                                                                                                                                                   
---------------------------------------------------------------------------                                                                                                                                        
ValueError                                Traceback (most recent call last)                                                                                                                                        
~/.local/share/virtualenvs/hooks_test-2daLLUaP/lib/python3.6/site-packages/botocore/utils.py in parse_timestamp(value)                                                                                             
    371         # enforce that GMT == UTC.                                                                                                                                                                         
--> 372         return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})                                                                                                                                      
    373     except (TypeError, ValueError) as e:                                                                                                                                                                   
                                                                                                                                                                                                                   
~/.local/share/virtualenvs/hooks_test-2daLLUaP/lib/python3.6/site-packages/dateutil/parser/_parser.py in parse(timestr, parserinfo, **kwargs)
   1355     else:
-> 1356         return DEFAULTPARSER.parse(timestr, **kwargs)
   1357

~/.local/share/virtualenvs/hooks_test-2daLLUaP/lib/python3.6/site-packages/dateutil/parser/_parser.py in parse(self, timestr, default, ignoretz, tzinfos, **kwargs)
    647         if res is None:
--> 648             raise ValueError("Unknown string format:", timestr)
    649

ValueError: ('Unknown string format:', 'Thu, 01 Jan 1970 00:00:00 GMT, Thu, 21 Jun 2018 11:44:44 GMT')
```

This PR returns a default `Last-Modified` just when not present.