### PR TITLE
Pick a more discriminative header for chunked content

### DIFF
--- a/src/main/scala/io/findify/s3mock/route/PutObject.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObject.scala
@@ -1,5 +1,6 @@
 package io.findify.s3mock.route
 
+import akka.event.Logging
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.stream.Materializer
@@ -20,7 +21,7 @@ import scala.util.{Failure, Success, Try}
 case class PutObject(implicit provider:Provider, mat:Materializer) extends LazyLogging {
   def route(bucket:String, path:String) = put {
     extractRequest { request =>
-      headerValueByName("authorization") { auth =>
+      headerValueByName("x-amz-decoded-content-length") { _ =>
         completeSigned(bucket, path)
       } ~ completePlain(bucket, path)
     }

--- a/src/main/scala/io/findify/s3mock/route/PutObject.scala
+++ b/src/main/scala/io/findify/s3mock/route/PutObject.scala
@@ -1,6 +1,5 @@
 package io.findify.s3mock.route
 
-import akka.event.Logging
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.stream.Materializer


### PR DESCRIPTION
 It happened that the condition for using chuking processing when doing a PutObject was the check for `authorization` header in the request. But this was creating some false positives with Python library boto3 when using it like:

```
client.upload_fileobj(BytesIO("hello world".encode("utf-8")), "mybucket", "test.txt")
```
Reading documentatoin in https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html it is clear that for chunked content one of the required headers is `x-amz-decoded-content-length` that is more unequivocal.

This PR is aiming at keeping the functionality as is (JavaExampleTest.scala keeps working) but at the same time make it interoperate with boto3.