### PR TITLE
Update library version in README to 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Not supported features (these might be implemented later):
 s3mock package is available for Scala 2.11/2.12 (on Java 8). To install using SBT, add these
  statements to your `build.sbt`:
 
-    libraryDependencies += "io.findify" %% "s3mock" % "0.2.4" % "test",
+    libraryDependencies += "io.findify" %% "s3mock" % "0.2.5" % "test",
 
 On maven, update your `pom.xml` in the following way:
 ```xml
@@ -36,7 +36,7 @@ On maven, update your `pom.xml` in the following way:
     <dependency>
         <groupId>io.findify</groupId>
         <artifactId>s3mock_2.12</artifactId>
-        <version>0.2.4</version>
+        <version>0.2.5</version>
         <scope>test</scope>
     </dependency>
 ```


### PR DESCRIPTION
The examples in the README use `S3Mock.shutdown`, which was introduced in 0.2.5 but the versions in the sbt/maven dependency strings are still 0.2.4