### PR TITLE
File descriptor leak in list bucket

### DIFF
--- a/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
@@ -49,8 +49,12 @@ class FileProvider(dir:String) extends Provider with LazyLogging {
       })
     val files = bucketFiles.map(f => {
       val stream = new FileInputStream(f.toJava)
-      val md5 = DigestUtils.md5Hex(stream)
-      Content(fromOs(f.toString).drop(bucketFileString.length+1).dropWhile(_ == '/'), DateTime(f.lastModifiedTime.toEpochMilli), md5, f.size, "STANDARD")
+      try {
+        val md5 = DigestUtils.md5Hex(stream)
+        Content(fromOs(f.toString).drop(bucketFileString.length+1).dropWhile(_ == '/'), DateTime(f.lastModifiedTime.toEpochMilli), md5, f.size, "STANDARD")
+      } finally {
+        stream.close()
+      }
     }).toList
     logger.debug(s"listing bucket contents: ${files.map(_.key)}")
     val commonPrefixes = delimiter match {


### PR DESCRIPTION
Small mistake when creating md5 sum, the close is missing from FileInputStream.
This causes to run the process out of file descriptors when listing buckets with a couple thousand files.