### PR TITLE
copyObject problem with directories

### DIFF
--- a/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
+++ b/src/main/scala/io/findify/s3mock/provider/FileProvider.scala
@@ -133,7 +133,7 @@ class FileProvider(dir:String) extends Provider with LazyLogging {
     if (!destBucketFile.exists) throw NoSuchBucketException(destBucket)
     val sourceFile = File(s"$dir/$sourceBucket/$sourceKey")
     val destFile = File(s"$dir/$destBucket/$destKey")
-    destFile.createIfNotExists(createParents = true)
+    destFile.createIfNotExists(asDirectory = sourceFile.isDirectory, createParents = true)
     sourceFile.copyTo(destFile, overwrite = true)
     logger.debug(s"Copied s3://$sourceBucket/$sourceKey to s3://$destBucket/$destKey")
     val sourceMeta = newMeta.orElse(metadataStore.get(sourceBucket, sourceKey))


### PR DESCRIPTION
when copying from src to dest, if src is a directory and dest doesn't exist, 
the dest parent will be created as a file instead of as a directory.
This results in a FileAlreadyExistsException in the call to copyTo on line 137

