### PR TITLE
Make it work with JDK10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
   "org.iq80.leveldb" % "leveldb" % "0.10",
-  "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "0.17" % "test"
+  "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "0.17" % "test",
+  "javax.xml.bind" % "jaxb-api" % "2.3.1"
 )
 
 parallelExecution in Test := false


### PR DESCRIPTION
I was running into issues JAXB-related `NoClassDefFound` on JDK10 when using `s3mock` as a test dependency in my Java project. Everything worked fine on JDK8. This appears to fix the problem. I believe this is related to #89.