### PR TITLE
DeleteObjects should encode object key like single-object APIs

### DIFF
--- a/src/main/scala/io/findify/s3mock/route/DeleteObjects.scala
+++ b/src/main/scala/io/findify/s3mock/route/DeleteObjects.scala
@@ -1,6 +1,6 @@
 package io.findify.s3mock.route
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives.{path, _}
 import com.typesafe.scalalogging.LazyLogging
 import io.findify.s3mock.error.NoSuchKeyException
@@ -19,7 +19,8 @@ case class DeleteObjects (implicit provider: Provider) extends LazyLogging {
       entity(as[String]) { xml => {
         complete {
           val request = DeleteObjectsRequest(scala.xml.XML.loadString(xml).head)
-          val response = request.objects.foldLeft(DeleteObjectsResponse(Nil, Nil))((res, path) => {
+          val response = request.objects.foldLeft(DeleteObjectsResponse(Nil, Nil))((res, rawPath) => {
+            val path = Uri.Path(rawPath).toString // URL-encoded
             Try(provider.deleteObject(bucket, path)) match {
               case Success(_) =>
                 logger.info(s"deleted object $bucket/$path")

--- a/src/test/java/io/findify/s3mock/example/JavaBuilderExample.java
+++ b/src/test/java/io/findify/s3mock/example/JavaBuilderExample.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Builder;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import io.findify.s3mock.S3Mock;
 
 /**
@@ -23,7 +24,8 @@ public class JavaBuilderExample {
                 .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
                 .build();
         client.createBucket("testbucket");
-        client.putObject("testbucket", "file/name", "contents");
+        client.putObject("testbucket", "file^name", "contents");
+        client.deleteObjects(new DeleteObjectsRequest("testbucket").withKeys("file^name"));
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/findify/s3mock/issues/166.