### PR TITLE
Logged real port used by S3Mock

### DIFF
--- a/src/main/scala/io/findify/s3mock/S3Mock.scala
+++ b/src/main/scala/io/findify/s3mock/S3Mock.scala
@@ -63,7 +63,7 @@ class S3Mock(port:Int, provider:Provider)(implicit system:ActorSystem = ActorSys
       }
 
     bind = Await.result(http.bindAndHandle(route, "0.0.0.0", port), Duration.Inf)
-    logger.info(s"bound to 0.0.0.0:$port")
+    logger.info(s"bound to 0.0.0.0:${bind.localAddress.getPort}")
     bind
   }
 


### PR DESCRIPTION
When given `port = 0`, akka-http will try to find an available port by itself, so the passed `port` parameter will not always be the one really used.