### PR TITLE
remove scala 2.11 support, update libs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ organization := "io.findify"
 
 scalaVersion in ThisBuild := "2.13.2"
 
-crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.10","2.13.2")
+crossScalaVersions in ThisBuild := Seq("2.12.13","2.13.2")
 
-val akkaVersion = "2.5.31"
+val akkaVersion = "2.6.17"
 
 licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 
@@ -16,20 +16,20 @@ homepage := Some(url("https://github.com/findify/s3mock"))
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "com.typesafe.akka" %% "akka-http" % "10.1.12",
+  "com.typesafe.akka" %% "akka-http" % "10.1.11",
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test",
-  "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6",
+  "org.scala-lang.modules" %% "scala-xml" % "2.0.1",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
   "com.github.pathikrit" %% "better-files" % "3.9.1",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.294",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.90",
+  "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.2.6" % "test",
   "org.iq80.leveldb" % "leveldb" % "0.12",
-  "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "1.1.2" % "test",
-  "javax.xml.bind" % "jaxb-api" % "2.3.0",
-  "com.sun.xml.bind" % "jaxb-core" % "2.3.0",
-  "com.sun.xml.bind" % "jaxb-impl" % "2.3.0"
+  "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "3.0.3" % "test",
+  "javax.xml.bind" % "jaxb-api" % "2.3.1",
+  "com.sun.xml.bind" % "jaxb-core" % "3.0.1",
+  "com.sun.xml.bind" % "jaxb-impl" % "3.0.1"
 )
 
 libraryDependencies ++= {

--- a/src/test/scala/io/findify/s3mock/ChunkBufferTest.scala
+++ b/src/test/scala/io/findify/s3mock/ChunkBufferTest.scala
@@ -1,12 +1,13 @@
 package io.findify.s3mock
 
 import akka.util.ByteString
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by shutty on 8/11/16.
   */
-class ChunkBufferTest extends FlatSpec with Matchers {
+class ChunkBufferTest extends AnyFlatSpec with Matchers {
   "chunk buffer" should "detect header" in {
     val cb = new ChunkBuffer()
     cb.addChunk(ByteString("3;chunk-signature=1234567890123456789012345678901234567890123456789012345678901234\r\nfoo\r\n"))

--- a/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
@@ -111,10 +111,10 @@ class GetPutObjectTest extends S3MockTest {
 
     it should "work with = in path" in {
       s3.createBucket("urlencoded")
-      s3.listBuckets().exists(_.getName == "urlencoded") shouldBe true
+      s3.listBuckets().asScala.exists(_.getName == "urlencoded") shouldBe true
       s3.putObject("urlencoded", "path/with=123/foo", "bar=")
       s3.putObject("urlencoded", "path/withoutequals/foo", "bar")
-      val result = s3.listObjects("urlencoded").getObjectSummaries.toList.map(_.getKey)
+      val result = s3.listObjects("urlencoded").getObjectSummaries.asScala.toList.map(_.getKey)
       result shouldBe List("path/with=123/foo", "path/withoutequals/foo")
       getContent(s3.getObject("urlencoded", "path/with=123/foo")) shouldBe "bar="
       getContent(s3.getObject("urlencoded", "path/withoutequals/foo")) shouldBe "bar"

--- a/src/test/scala/io/findify/s3mock/MapMetadataStoreTest.scala
+++ b/src/test/scala/io/findify/s3mock/MapMetadataStoreTest.scala
@@ -4,11 +4,13 @@ import java.util
 
 import com.amazonaws.services.s3.model.ObjectMetadata
 import io.findify.s3mock.provider.metadata.{InMemoryMetadataStore, MapMetadataStore, MetadataStore}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 /**
   * Created by shutty on 3/13/17.
   */
-class MapMetadataStoreTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+class MapMetadataStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   for (metadataStore <- List((new MapMetadataStore("/tmp/s3"), "MapMetadataStore"),
     (new InMemoryMetadataStore, "InMemoryMetadataStore"))) {

--- a/src/test/scala/io/findify/s3mock/S3ChunkedProtocolTest.scala
+++ b/src/test/scala/io/findify/s3mock/S3ChunkedProtocolTest.scala
@@ -1,19 +1,19 @@
 package io.findify.s3mock
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
-import org.scalatest.{FlatSpec, Matchers}
 import scala.concurrent.duration._
 import scala.concurrent.Await
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by shutty on 8/11/16.
   */
-class S3ChunkedProtocolTest extends FlatSpec with Matchers {
+class S3ChunkedProtocolTest extends AnyFlatSpec with Matchers {
   implicit val system = ActorSystem.create("test")
-  implicit val mat = ActorMaterializer()
 
   "s3 chunk protocol" should "work with simple ins" in {
     val in = "3;chunk-signature=1234567890123456789012345678901234567890123456789012345678901234\r\nfoo\r\n3;chunk-signature=1234567890123456789012345678901234567890123456789012345678901234\r\nbar\r\n".grouped(10).map(ByteString(_)).toList

--- a/src/test/scala/io/findify/s3mock/S3MockTest.scala
+++ b/src/test/scala/io/findify/s3mock/S3MockTest.scala
@@ -1,7 +1,6 @@
 package io.findify.s3mock
 
 import akka.actor.ActorSystem
-import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.{ActorMaterializer, Materializer}
 import better.files.File
@@ -12,18 +11,20 @@ import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.findify.s3mock.provider.{FileProvider, InMemoryProvider}
-
 import scala.collection.JavaConverters._
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
+import org.scalatest.BeforeAndAfterAll
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.io.Source
 
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 /**
   * Created by shutty on 8/9/16.
   */
-trait S3MockTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+trait S3MockTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   private val workDir = File.newTemporaryDirectory().pathAsString
   private val fileBasedPort = 8001
   private val fileSystemConfig = configFor("localhost", fileBasedPort)

--- a/src/test/scala/io/findify/s3mock/alpakka/ListBucketTest.scala
+++ b/src/test/scala/io/findify/s3mock/alpakka/ListBucketTest.scala
@@ -1,7 +1,6 @@
 package io.findify.s3mock.alpakka
 
 import akka.stream.scaladsl.Sink
-import akka.util.ByteString
 import io.findify.s3mock.S3MockTest
 import scala.concurrent.duration._
 import scala.concurrent.Await


### PR DESCRIPTION
Updating libraries for Scala 2.12 and 2.13 went pretty smooth.
Some of the newest libs are not any more compiled with Scala 2.11. Therefore, I dropped support for Scala 2.11.