### PR TITLE
fix ListBucket xml response

### DIFF
--- a/src/main/scala/io/findify/s3mock/response/ListBucket.scala
+++ b/src/main/scala/io/findify/s3mock/response/ListBucket.scala
@@ -11,9 +11,15 @@ case class ListBucket(bucket:String, prefix: Option[String], delimiter: Option[S
   def toXML =
     <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
       <Name>{bucket}</Name>
-      { prefix.map(p => <Prefix>{p}</Prefix> ) }
-      { delimiter.map(d => <Delimiter>{d}</Delimiter>) }
-      { if (commonPrefixes.nonEmpty) <CommonPrefixes> {commonPrefixes.map(cp => <Prefix>{cp}</Prefix>)} </CommonPrefixes> }
+      { if (prefix.isDefined) <Prefix>{prefix.get}</Prefix> }
+      { if (delimiter.isDefined) <Delimiter>{delimiter.get}</Delimiter> }
+      { if (commonPrefixes.nonEmpty)
+      {commonPrefixes.map(cp =>
+      <CommonPrefixes>
+        <Prefix>{cp}</Prefix>
+      </CommonPrefixes>
+      )}
+      }
       <KeyCount>{contents.length}</KeyCount>
       <MaxKeys>1000</MaxKeys>
       <IsTruncated>{isTruncated}</IsTruncated>

--- a/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
+++ b/src/test/scala/io/findify/s3mock/GetPutObjectTest.scala
@@ -111,10 +111,10 @@ class GetPutObjectTest extends S3MockTest {
 
     it should "work with = in path" in {
       s3.createBucket("urlencoded")
-      s3.listBuckets().exists(_.getName == "urlencoded") shouldBe true
+      s3.listBuckets().asScala.exists(_.getName == "urlencoded") shouldBe true
       s3.putObject("urlencoded", "path/with=123/foo", "bar=")
       s3.putObject("urlencoded", "path/withoutequals/foo", "bar")
-      val result = s3.listObjects("urlencoded").getObjectSummaries.toList.map(_.getKey)
+      val result = s3.listObjects("urlencoded").getObjectSummaries.asScala.toList.map(_.getKey)
       result shouldBe List("path/with=123/foo", "path/withoutequals/foo")
       getContent(s3.getObject("urlencoded", "path/with=123/foo")) shouldBe "bar="
       getContent(s3.getObject("urlencoded", "path/withoutequals/foo")) shouldBe "bar"


### PR DESCRIPTION
I bumped into a strange behavior in Alpakka S3 when using `S3.listBucketAndCommonPrefixes` with s3mock. According to https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html, `CommonPrefix` should be repeated for each common prefix, which is currently not the case in s3mock.

The following is copied from https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html:
```
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Name>example-bucket</Name>
  <Prefix>photos/2006/</Prefix>
  <KeyCount>3</KeyCount>
  <MaxKeys>1000</MaxKeys>
  <Delimiter>/</Delimiter>
  <IsTruncated>false</IsTruncated>
  <Contents>
    <Key>photos/2006/</Key>
    <LastModified>2016-04-30T23:51:29.000Z</LastModified>
    <ETag>"d41d8cd98f00b204e9800998ecf8427e"</ETag>
    <Size>0</Size>
    <StorageClass>STANDARD</StorageClass>
  </Contents>

  <CommonPrefixes>
    <Prefix>photos/2006/February/</Prefix>
  </CommonPrefixes>
  <CommonPrefixes>
    <Prefix>photos/2006/January/</Prefix>
  </CommonPrefixes>
</ListBucketResult>
```

Notice multiple occurrences of `CommonPrefix`

`Prefix` and `Delimiter` weren't serialized to XML properly either. This is now fixed.

